### PR TITLE
Pipe-through template parameters for `Package`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ target_sources(${PROJECT_NAME} INTERFACE
                $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include/dd/Edge.hpp>
                $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include/dd/Export.hpp>
                $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include/dd/GateMatrixDefinitions.hpp>
+               $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include/dd/Node.hpp>
                $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include/dd/NoiseOperationTable.hpp>
                $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include/dd/Package.hpp>
                $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include/dd/ToffoliTable.hpp>

--- a/include/dd/Export.hpp
+++ b/include/dd/Export.hpp
@@ -248,7 +248,7 @@ namespace dd {
         return os;
     }
 
-    [[maybe_unused]] static std::ostream& modernNode(const Package::mEdge& e, std::ostream& os, bool formatAsPolar = true) {
+    [[maybe_unused]] static std::ostream& modernNode(const mEdge& e, std::ostream& os, bool formatAsPolar = true) {
         auto nodelabel = (reinterpret_cast<std::uintptr_t>(e.p) & 0x001fffffU) >> 1U; // this allows for 2^20 (roughly 1e6) unique nodes
         os << nodelabel << "[label=<";
         os << R"(<font point-size="10"><table border="1" cellspacing="0" cellpadding="2" style="rounded">)";
@@ -265,7 +265,7 @@ namespace dd {
         os << "</table></font>>,tooltip=\"q" << static_cast<std::size_t>(e.p->v) << "\"]\n";
         return os;
     }
-    [[maybe_unused]] static std::ostream& modernNode(const Package::vEdge& e, std::ostream& os, bool formatAsPolar = true) {
+    [[maybe_unused]] static std::ostream& modernNode(const vEdge& e, std::ostream& os, bool formatAsPolar = true) {
         auto nodelabel = (reinterpret_cast<std::uintptr_t>(e.p) & 0x001fffffU) >> 1U; // this allows for 2^20 (roughly 1e6) unique nodes
         os << nodelabel << "[label=<";
         os << R"(<font point-size="8"><table border="1" cellspacing="0" cellpadding="0" style="rounded">)";
@@ -275,7 +275,7 @@ namespace dd {
         os << "</tr></table></font>>,tooltip=\"q" << static_cast<std::size_t>(e.p->v) << "\"]\n";
         return os;
     }
-    [[maybe_unused]] static std::ostream& classicNode(const Package::mEdge& e, std::ostream& os, bool formatAsPolar = true) {
+    [[maybe_unused]] static std::ostream& classicNode(const mEdge& e, std::ostream& os, bool formatAsPolar = true) {
         auto nodelabel = (reinterpret_cast<std::uintptr_t>(e.p) & 0x001fffffU) >> 1U; // this allows for 2^20 (roughly 1e6) unique nodes
         os << nodelabel << "[shape=circle, width=0.53, fixedsize=true, label=<";
         os << R"(<font point-size="6"><table border="0" cellspacing="0" cellpadding="0">)";
@@ -313,7 +313,7 @@ namespace dd {
         os << "<td></td></tr></table></font>>,tooltip=\"q" << static_cast<std::size_t>(e.p->v) << "\"]\n";
         return os;
     }
-    [[maybe_unused]] static std::ostream& classicNode(const Package::vEdge& e, std::ostream& os, bool formatAsPolar = true) {
+    [[maybe_unused]] static std::ostream& classicNode(const vEdge& e, std::ostream& os, bool formatAsPolar = true) {
         auto nodelabel = (reinterpret_cast<std::uintptr_t>(e.p) & 0x001fffffU) >> 1U; // this allows for 2^20 (roughly 1e6) unique nodes
         os << nodelabel << "[shape=circle, width=0.46, fixedsize=true, label=<";
         os << R"(<font point-size="6"><table border="0" cellspacing="0" cellpadding="0">)";
@@ -359,7 +359,7 @@ namespace dd {
         return os;
     }
 
-    [[maybe_unused]] static std::ostream& bwEdge(const Package::mEdge& from, const Package::mEdge& to, short idx, std::ostream& os, bool edgeLabels = false, bool classic = false, bool formatAsPolar = true) {
+    [[maybe_unused]] static std::ostream& bwEdge(const mEdge& from, const mEdge& to, short idx, std::ostream& os, bool edgeLabels = false, bool classic = false, bool formatAsPolar = true) {
         auto fromlabel = (reinterpret_cast<std::uintptr_t>(from.p) & 0x001fffffU) >> 1U;
         auto tolabel   = (reinterpret_cast<std::uintptr_t>(to.p) & 0x001fffffU) >> 1U;
 
@@ -398,7 +398,7 @@ namespace dd {
 
         return os;
     }
-    [[maybe_unused]] static std::ostream& bwEdge(const Package::vEdge& from, const Package::vEdge& to, short idx, std::ostream& os, bool edgeLabels = false, [[maybe_unused]] bool classic = false, bool formatAsPolar = true) {
+    [[maybe_unused]] static std::ostream& bwEdge(const vEdge& from, const vEdge& to, short idx, std::ostream& os, bool edgeLabels = false, [[maybe_unused]] bool classic = false, bool formatAsPolar = true) {
         auto fromlabel = (reinterpret_cast<std::uintptr_t>(from.p) & 0x001fffffU) >> 1U;
         auto tolabel   = (reinterpret_cast<std::uintptr_t>(to.p) & 0x001fffffU) >> 1U;
 
@@ -422,7 +422,7 @@ namespace dd {
 
         return os;
     }
-    [[maybe_unused]] static std::ostream& coloredEdge(const Package::mEdge& from, const Package::mEdge& to, short idx, std::ostream& os, bool edgeLabels = false, bool classic = false, bool formatAsPolar = true) {
+    [[maybe_unused]] static std::ostream& coloredEdge(const mEdge& from, const mEdge& to, short idx, std::ostream& os, bool edgeLabels = false, bool classic = false, bool formatAsPolar = true) {
         auto fromlabel = (reinterpret_cast<std::uintptr_t>(from.p) & 0x001fffffU) >> 1U;
         auto tolabel   = (reinterpret_cast<std::uintptr_t>(to.p) & 0x001fffffU) >> 1U;
 
@@ -459,7 +459,7 @@ namespace dd {
 
         return os;
     }
-    [[maybe_unused]] static std::ostream& coloredEdge(const Package::vEdge& from, const Package::vEdge& to, short idx, std::ostream& os, bool edgeLabels = false, [[maybe_unused]] bool classic = false, bool formatAsPolar = true) {
+    [[maybe_unused]] static std::ostream& coloredEdge(const vEdge& from, const vEdge& to, short idx, std::ostream& os, bool edgeLabels = false, [[maybe_unused]] bool classic = false, bool formatAsPolar = true) {
         auto fromlabel = (reinterpret_cast<std::uintptr_t>(from.p) & 0x001fffffU) >> 1U;
         auto tolabel   = (reinterpret_cast<std::uintptr_t>(to.p) & 0x001fffffU) >> 1U;
 
@@ -614,7 +614,7 @@ namespace dd {
     /// Note: do not rely on the binary format being portable across different architectures/platforms
     ///
 
-    [[maybe_unused]] static void serialize(const Package::vEdge& basic, std::ostream& os, bool writeBinary = false) {
+    [[maybe_unused]] static void serialize(const vEdge& basic, std::ostream& os, bool writeBinary = false) {
         if (writeBinary) {
             os.write(reinterpret_cast<const char*>(&SERIALIZATION_VERSION), sizeof(decltype(SERIALIZATION_VERSION)));
             basic.w.writeBinary(os);
@@ -622,11 +622,11 @@ namespace dd {
             os << SERIALIZATION_VERSION << "\n";
             os << basic.w.toString(false, 16) << "\n";
         }
-        std::int_least64_t                                      next_index = 0;
-        std::unordered_map<Package::vNode*, std::int_least64_t> node_index{};
+        std::int_least64_t                             next_index = 0;
+        std::unordered_map<vNode*, std::int_least64_t> node_index{};
 
         // POST ORDER TRAVERSAL USING ONE STACK   https://www.geeksforgeeks.org/iterative-postorder-traversal-using-stack/
-        std::stack<const Package::vEdge*> stack{};
+        std::stack<const vEdge*> stack{};
 
         auto node = &basic;
         if (!node->isTerminal()) {
@@ -700,7 +700,7 @@ namespace dd {
             } while (!stack.empty());
         }
     }
-    static void serializeMatrix(const Package::mEdge& basic, std::int_least64_t& idx, std::unordered_map<Package::mNode*, std::int_least64_t>& node_index, std::unordered_set<Package::mNode*>& visited, std::ostream& os, bool writeBinary = false) {
+    static void serializeMatrix(const mEdge& basic, std::int_least64_t& idx, std::unordered_map<mNode*, std::int_least64_t>& node_index, std::unordered_set<mNode*>& visited, std::ostream& os, bool writeBinary = false) {
         if (!basic.isTerminal()) {
             for (auto& e: basic.p->e) {
                 if (auto [iter, success] = visited.insert(e.p); success) {
@@ -739,7 +739,7 @@ namespace dd {
             }
         }
     }
-    [[maybe_unused]] static void serialize(const Package::mEdge& basic, std::ostream& os, bool writeBinary = false) {
+    [[maybe_unused]] static void serialize(const mEdge& basic, std::ostream& os, bool writeBinary = false) {
         if (writeBinary) {
             os.write(reinterpret_cast<const char*>(&SERIALIZATION_VERSION), sizeof(decltype(SERIALIZATION_VERSION)));
             basic.w.writeBinary(os);
@@ -747,9 +747,9 @@ namespace dd {
             os << SERIALIZATION_VERSION << "\n";
             os << basic.w.toString(false, std::numeric_limits<dd::fp>::max_digits10) << "\n";
         }
-        std::int_least64_t                                      idx = 0;
-        std::unordered_map<Package::mNode*, std::int_least64_t> node_index{};
-        std::unordered_set<Package::mNode*>                     visited{};
+        std::int_least64_t                             idx = 0;
+        std::unordered_map<mNode*, std::int_least64_t> node_index{};
+        std::unordered_set<mNode*>                     visited{};
         serializeMatrix(basic, idx, node_index, visited, os, writeBinary);
     }
     template<class Edge>

--- a/include/dd/Node.hpp
+++ b/include/dd/Node.hpp
@@ -1,0 +1,47 @@
+/*
+* This file is part of the MQT DD Package which is released under the MIT license.
+* See file README.md or go to http://iic.jku.at/eda/research/quantum_dd/ for more information.
+*/
+
+#pragma once
+
+#include "Definitions.hpp"
+#include "Edge.hpp"
+
+#include <array>
+
+namespace dd {
+    struct vNode {
+        std::array<Edge<vNode>, RADIX> e{};    // edges out of this node
+        vNode*                         next{}; // used to link nodes in unique table
+        RefCount                       ref{};  // reference count
+        Qubit                          v{};    // variable index (nonterminal) value (-1 for terminal)
+
+        static vNode            terminalNode;
+        constexpr static vNode* terminal{&terminalNode};
+
+        static constexpr bool isTerminal(const vNode* p) { return p == terminal; }
+    };
+    using vEdge       = Edge<vNode>;
+    using vCachedEdge = CachedEdge<vNode>;
+
+    inline vNode vNode::terminalNode{{{{nullptr, Complex::zero}, {nullptr, Complex::zero}}}, nullptr, 0U, -1};
+
+    struct mNode {
+        std::array<Edge<mNode>, NEDGE> e{};           // edges out of this node
+        mNode*                         next{};        // used to link nodes in unique table
+        RefCount                       ref{};         // reference count
+        Qubit                          v{};           // variable index (nonterminal) value (-1 for terminal)
+        bool                           symm  = false; // node is symmetric
+        bool                           ident = false; // node resembles identity
+
+        static mNode            terminalNode;
+        constexpr static mNode* terminal{&terminalNode};
+
+        static constexpr bool isTerminal(const mNode* p) { return p == terminal; }
+    };
+    using mEdge       = Edge<mNode>;
+    using mCachedEdge = CachedEdge<mNode>;
+
+    inline mNode mNode::terminalNode{{{{nullptr, Complex::zero}, {nullptr, Complex::zero}, {nullptr, Complex::zero}, {nullptr, Complex::zero}}}, nullptr, 0U, -1, true, true};
+} // namespace dd

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -16,6 +16,7 @@
 #include "Definitions.hpp"
 #include "Edge.hpp"
 #include "GateMatrixDefinitions.hpp"
+#include "Node.hpp"
 #include "NoiseOperationTable.hpp"
 #include "ToffoliTable.hpp"
 #include "UnaryComputeTable.hpp"
@@ -46,6 +47,19 @@
 #include <vector>
 
 namespace dd {
+    template<std::size_t UT_VEC_NBUCKET                 = 32768U,
+             std::size_t UT_VEC_INITIAL_ALLOCATION_SIZE = 2048U,
+             std::size_t UT_MAT_NBUCKET                 = 32768U,
+             std::size_t UT_MAT_INITIAL_ALLOCATION_SIZE = 2048U,
+             std::size_t CT_VEC_ADD_NBUCKET             = 16384U,
+             std::size_t CT_MAT_ADD_NBUCKET             = 16384U,
+             std::size_t CT_MAT_TRANS_NBUCKET           = 4096U,
+             std::size_t CT_MAT_CONJ_TRANS_NBUCKET      = 4096U,
+             std::size_t CT_MAT_VEC_MULT_NBUCKET        = 16384U,
+             std::size_t CT_MAT_MAT_MULT_NBUCKET        = 16384U,
+             std::size_t CT_VEC_INNER_PROD_NBUCKET      = 4096U,
+             std::size_t CT_VEC_KRON_NBUCKET            = 4096U,
+             std::size_t CT_MAT_KRON_NBUCKET            = 4096U>
     class Package {
         ///
         /// Complex number handling
@@ -63,8 +77,8 @@ namespace dd {
             cn(ComplexNumbers()), nqubits(nq) {
             resize(nq);
         };
-        ~Package()                      = default;
-        Package(const Package& package) = delete;
+        ~Package()                                 = default;
+        Package(const Package& package)            = delete;
         Package& operator=(const Package& package) = delete;
 
         // resize the package instance
@@ -98,20 +112,6 @@ namespace dd {
         /// Vector nodes, edges and quantum states
         ///
     public:
-        struct vNode {
-            std::array<Edge<vNode>, RADIX> e{};    // edges out of this node
-            vNode*                         next{}; // used to link nodes in unique table
-            RefCount                       ref{};  // reference count
-            Qubit                          v{};    // variable index (nonterminal) value (-1 for terminal)
-
-            static vNode            terminalNode;
-            constexpr static vNode* terminal{&terminalNode};
-
-            static constexpr bool isTerminal(const vNode* p) { return p == terminal; }
-        };
-        using vEdge       = Edge<vNode>;
-        using vCachedEdge = CachedEdge<vNode>;
-
         vEdge normalize(const vEdge& e, bool cached) {
             auto zero = std::array{e.p->e[0].w.approximatelyZero(), e.p->e[1].w.approximatelyZero()};
 
@@ -279,22 +279,6 @@ namespace dd {
         /// Matrix nodes, edges and quantum gates
         ///
     public:
-        struct mNode {
-            std::array<Edge<mNode>, NEDGE> e{};           // edges out of this node
-            mNode*                         next{};        // used to link nodes in unique table
-            RefCount                       ref{};         // reference count
-            Qubit                          v{};           // variable index (nonterminal) value (-1 for terminal)
-            bool                           symm  = false; // node is symmetric
-            bool                           ident = false; // node resembles identity
-
-            static mNode            terminalNode;
-            constexpr static mNode* terminal{&terminalNode};
-
-            static constexpr bool isTerminal(const mNode* p) { return p == terminal; }
-        };
-        using mEdge       = Edge<mNode>;
-        using mCachedEdge = CachedEdge<mNode>;
-
         mEdge normalize(const mEdge& e, bool cached) {
             auto argmax = -1;
 
@@ -522,7 +506,13 @@ namespace dd {
     public:
         // unique tables
         template<class Node>
-        [[nodiscard]] UniqueTable<Node>& getUniqueTable();
+        [[nodiscard]] auto& getUniqueTable() {
+            if constexpr (std::is_same_v<Node, vNode>) {
+                return vUniqueTable;
+            } else {
+                return mUniqueTable;
+            }
+        }
 
         template<class Node>
         void incRef(const Edge<Node>& e) {
@@ -533,8 +523,8 @@ namespace dd {
             getUniqueTable<Node>().decRef(e);
         }
 
-        UniqueTable<vNode> vUniqueTable{nqubits};
-        UniqueTable<mNode> mUniqueTable{nqubits};
+        UniqueTable<vNode, UT_VEC_NBUCKET, UT_VEC_INITIAL_ALLOCATION_SIZE> vUniqueTable{nqubits};
+        UniqueTable<mNode, UT_MAT_NBUCKET, UT_MAT_INITIAL_ALLOCATION_SIZE> mUniqueTable{nqubits};
 
         bool garbageCollect(bool force = false) {
             // return immediately if no table needs collection
@@ -888,11 +878,17 @@ namespace dd {
         /// Addition
         ///
     public:
-        ComputeTable<vCachedEdge, vCachedEdge, vCachedEdge> vectorAdd{};
-        ComputeTable<mCachedEdge, mCachedEdge, mCachedEdge> matrixAdd{};
+        ComputeTable<vCachedEdge, vCachedEdge, vCachedEdge, CT_VEC_ADD_NBUCKET> vectorAdd{};
+        ComputeTable<mCachedEdge, mCachedEdge, mCachedEdge, CT_MAT_ADD_NBUCKET> matrixAdd{};
 
         template<class Node>
-        [[nodiscard]] ComputeTable<CachedEdge<Node>, CachedEdge<Node>, CachedEdge<Node>>& getAddComputeTable();
+        [[nodiscard]] auto& getAddComputeTable() {
+            if constexpr (std::is_same_v<Node, vNode>) {
+                return vectorAdd;
+            } else {
+                return matrixAdd;
+            }
+        }
 
         template<class Edge>
         Edge add(const Edge& x, const Edge& y) {
@@ -1008,8 +1004,8 @@ namespace dd {
         /// Matrix (conjugate) transpose
         ///
     public:
-        UnaryComputeTable<mEdge, mEdge, 4096> matrixTranspose{};
-        UnaryComputeTable<mEdge, mEdge, 4096> conjugateMatrixTranspose{};
+        UnaryComputeTable<mEdge, mEdge, CT_MAT_TRANS_NBUCKET>      matrixTranspose{};
+        UnaryComputeTable<mEdge, mEdge, CT_MAT_CONJ_TRANS_NBUCKET> conjugateMatrixTranspose{};
 
         mEdge transpose(const mEdge& a) {
             if (a.p == nullptr || a.isTerminal() || a.p->symm) {
@@ -1079,11 +1075,17 @@ namespace dd {
         /// Multiplication
         ///
     public:
-        ComputeTable<mEdge, vEdge, vCachedEdge> matrixVectorMultiplication{};
-        ComputeTable<mEdge, mEdge, mCachedEdge> matrixMatrixMultiplication{};
+        ComputeTable<mEdge, vEdge, vCachedEdge, CT_MAT_VEC_MULT_NBUCKET> matrixVectorMultiplication{};
+        ComputeTable<mEdge, mEdge, mCachedEdge, CT_MAT_MAT_MULT_NBUCKET> matrixMatrixMultiplication{};
 
         template<class LeftOperandNode, class RightOperandNode>
-        [[nodiscard]] ComputeTable<Edge<LeftOperandNode>, Edge<RightOperandNode>, CachedEdge<RightOperandNode>>& getMultiplicationComputeTable();
+        [[nodiscard]] auto& getMultiplicationComputeTable() {
+            if constexpr (std::is_same_v<RightOperandNode, vNode>) {
+                return matrixVectorMultiplication;
+            } else {
+                return matrixMatrixMultiplication;
+            }
+        }
 
         template<class LeftOperand, class RightOperand>
         RightOperand multiply(const LeftOperand& x, const RightOperand& y, dd::Qubit start = 0) {
@@ -1249,7 +1251,7 @@ namespace dd {
         /// Inner product and fidelity
         ///
     public:
-        ComputeTable<vEdge, vEdge, vCachedEdge, 4096> vectorInnerProduct{};
+        ComputeTable<vEdge, vEdge, vCachedEdge, CT_VEC_INNER_PROD_NBUCKET> vectorInnerProduct{};
 
         ComplexValue innerProduct(const vEdge& x, const vEdge& y) {
             if (x.p == nullptr || y.p == nullptr || x.w.approximatelyZero() || y.w.approximatelyZero()) { // the 0 case
@@ -1367,11 +1369,17 @@ namespace dd {
         /// Kronecker/tensor product
         ///
     public:
-        ComputeTable<vEdge, vEdge, vCachedEdge, 4096> vectorKronecker{};
-        ComputeTable<mEdge, mEdge, mCachedEdge, 4096> matrixKronecker{};
+        ComputeTable<vEdge, vEdge, vCachedEdge, CT_VEC_KRON_NBUCKET> vectorKronecker{};
+        ComputeTable<mEdge, mEdge, mCachedEdge, CT_MAT_KRON_NBUCKET> matrixKronecker{};
 
         template<class Node>
-        [[nodiscard]] ComputeTable<Edge<Node>, Edge<Node>, CachedEdge<Node>, 4096>& getKroneckerComputeTable();
+        [[nodiscard]] auto& getKroneckerComputeTable() {
+            if constexpr (std::is_same_v<Node, vNode>) {
+                return vectorKronecker;
+            } else {
+                return matrixKronecker;
+            }
+        }
 
         template<class Edge>
         Edge kronecker(const Edge& x, const Edge& y, bool incIdx = true) {
@@ -2080,7 +2088,7 @@ namespace dd {
             cn.returnToCache(c);
         }
 
-        void exportAmplitudesRec(const dd::Package::vEdge& edge, std::ostream& oss, const std::string& path, Complex& amplitude, dd::QubitCount level, bool binary = false) {
+        void exportAmplitudesRec(const vEdge& edge, std::ostream& oss, const std::string& path, Complex& amplitude, dd::QubitCount level, bool binary = false) {
             if (edge.isTerminal()) {
                 auto amp = cn.getTemporary();
                 dd::ComplexNumbers::mul(amp, amplitude, edge.w);
@@ -2100,7 +2108,7 @@ namespace dd {
             exportAmplitudesRec(edge.p->e[1], oss, path + "1", a, level - 1, binary);
             cn.returnToCache(a);
         }
-        void exportAmplitudes(const dd::Package::vEdge& edge, std::ostream& oss, dd::QubitCount nq, bool binary = false) {
+        void exportAmplitudes(const vEdge& edge, std::ostream& oss, dd::QubitCount nq, bool binary = false) {
             if (edge.isTerminal()) {
                 // TODO special treatment
                 return;
@@ -2109,7 +2117,7 @@ namespace dd {
             exportAmplitudesRec(edge, oss, "", weight, nq, binary);
             cn.returnToCache(weight);
         }
-        void exportAmplitudes(const dd::Package::vEdge& edge, const std::string& outputFilename, dd::QubitCount nq, bool binary = false) {
+        void exportAmplitudes(const vEdge& edge, const std::string& outputFilename, dd::QubitCount nq, bool binary = false) {
             std::ofstream      init(outputFilename);
             std::ostringstream oss{};
 
@@ -2119,7 +2127,7 @@ namespace dd {
             init.close();
         }
 
-        void exportAmplitudesRec(const dd::Package::vEdge& edge, std::vector<std::complex<dd::fp>>& amplitudes, Complex& amplitude, dd::QubitCount level, std::size_t idx) {
+        void exportAmplitudesRec(const vEdge& edge, std::vector<std::complex<dd::fp>>& amplitudes, Complex& amplitude, dd::QubitCount level, std::size_t idx) {
             if (edge.isTerminal()) {
                 auto amp = cn.getTemporary();
                 dd::ComplexNumbers::mul(amp, amplitude, edge.w);
@@ -2136,7 +2144,7 @@ namespace dd {
             exportAmplitudesRec(edge.p->e[1], amplitudes, a, level - 1, (idx << 1) | 1ULL);
             cn.returnToCache(a);
         }
-        void exportAmplitudes(const dd::Package::vEdge& edge, std::vector<std::complex<dd::fp>>& amplitudes, dd::QubitCount nq) {
+        void exportAmplitudes(const vEdge& edge, std::vector<std::complex<dd::fp>>& amplitudes, dd::QubitCount nq) {
             if (edge.isTerminal()) {
                 // TODO special treatment
                 return;
@@ -2146,7 +2154,7 @@ namespace dd {
             cn.returnToCache(weight);
         }
 
-        void addAmplitudesRec(const dd::Package::vEdge& edge, std::vector<std::complex<dd::fp>>& amplitudes, ComplexValue& amplitude, dd::QubitCount level, std::size_t idx) {
+        void addAmplitudesRec(const vEdge& edge, std::vector<std::complex<dd::fp>>& amplitudes, ComplexValue& amplitude, dd::QubitCount level, std::size_t idx) {
             auto         ar = dd::ComplexTable<>::Entry::val(edge.w.r);
             auto         ai = dd::ComplexTable<>::Entry::val(edge.w.i);
             ComplexValue amp{ar * amplitude.r - ai * amplitude.i, ar * amplitude.i + ai * amplitude.r};
@@ -2164,7 +2172,7 @@ namespace dd {
             addAmplitudesRec(edge.p->e[0], amplitudes, amp, level - 1, idx << 1);
             addAmplitudesRec(edge.p->e[1], amplitudes, amp, level - 1, idx << 1 | 1ULL);
         }
-        void addAmplitudes(const dd::Package::vEdge& edge, std::vector<std::complex<dd::fp>>& amplitudes, dd::QubitCount nq) {
+        void addAmplitudes(const vEdge& edge, std::vector<std::complex<dd::fp>>& amplitudes, dd::QubitCount nq) {
             if (edge.isTerminal()) {
                 // TODO special treatment
                 return;
@@ -2563,15 +2571,15 @@ namespace dd {
                       << "\n  vNode size: " << sizeof(vNode) << " bytes (aligned " << alignof(vNode) << " bytes)"
                       << "\n  mEdge size: " << sizeof(mEdge) << " bytes (aligned " << alignof(mEdge) << " bytes)"
                       << "\n  mNode size: " << sizeof(mNode) << " bytes (aligned " << alignof(mNode) << " bytes)"
-                      << "\n  CT Vector Add size: " << sizeof(decltype(vectorAdd)::Entry) << " bytes (aligned " << alignof(decltype(vectorAdd)::Entry) << " bytes)"
-                      << "\n  CT Matrix Add size: " << sizeof(decltype(matrixAdd)::Entry) << " bytes (aligned " << alignof(decltype(matrixAdd)::Entry) << " bytes)"
-                      << "\n  CT Matrix Transpose size: " << sizeof(decltype(matrixTranspose)::Entry) << " bytes (aligned " << alignof(decltype(matrixTranspose)::Entry) << " bytes)"
-                      << "\n  CT Conjugate Matrix Transpose size: " << sizeof(decltype(conjugateMatrixTranspose)::Entry) << " bytes (aligned " << alignof(decltype(conjugateMatrixTranspose)::Entry) << " bytes)"
-                      << "\n  CT Matrix Multiplication size: " << sizeof(decltype(matrixMatrixMultiplication)::Entry) << " bytes (aligned " << alignof(decltype(matrixMatrixMultiplication)::Entry) << " bytes)"
-                      << "\n  CT Matrix Vector Multiplication size: " << sizeof(decltype(matrixVectorMultiplication)::Entry) << " bytes (aligned " << alignof(decltype(matrixVectorMultiplication)::Entry) << " bytes)"
-                      << "\n  CT Vector Inner Product size: " << sizeof(decltype(vectorInnerProduct)::Entry) << " bytes (aligned " << alignof(decltype(vectorInnerProduct)::Entry) << " bytes)"
-                      << "\n  CT Vector Kronecker size: " << sizeof(decltype(vectorKronecker)::Entry) << " bytes (aligned " << alignof(decltype(vectorKronecker)::Entry) << " bytes)"
-                      << "\n  CT Matrix Kronecker size: " << sizeof(decltype(matrixKronecker)::Entry) << " bytes (aligned " << alignof(decltype(matrixKronecker)::Entry) << " bytes)"
+                      << "\n  CT Vector Add size: " << sizeof(typename decltype(vectorAdd)::Entry) << " bytes (aligned " << alignof(typename decltype(vectorAdd)::Entry) << " bytes)"
+                      << "\n  CT Matrix Add size: " << sizeof(typename decltype(matrixAdd)::Entry) << " bytes (aligned " << alignof(typename decltype(matrixAdd)::Entry) << " bytes)"
+                      << "\n  CT Matrix Transpose size: " << sizeof(typename decltype(matrixTranspose)::Entry) << " bytes (aligned " << alignof(typename decltype(matrixTranspose)::Entry) << " bytes)"
+                      << "\n  CT Conjugate Matrix Transpose size: " << sizeof(typename decltype(conjugateMatrixTranspose)::Entry) << " bytes (aligned " << alignof(typename decltype(conjugateMatrixTranspose)::Entry) << " bytes)"
+                      << "\n  CT Matrix Multiplication size: " << sizeof(typename decltype(matrixMatrixMultiplication)::Entry) << " bytes (aligned " << alignof(typename decltype(matrixMatrixMultiplication)::Entry) << " bytes)"
+                      << "\n  CT Matrix Vector Multiplication size: " << sizeof(typename decltype(matrixVectorMultiplication)::Entry) << " bytes (aligned " << alignof(typename decltype(matrixVectorMultiplication)::Entry) << " bytes)"
+                      << "\n  CT Vector Inner Product size: " << sizeof(typename decltype(vectorInnerProduct)::Entry) << " bytes (aligned " << alignof(typename decltype(vectorInnerProduct)::Entry) << " bytes)"
+                      << "\n  CT Vector Kronecker size: " << sizeof(typename decltype(vectorKronecker)::Entry) << " bytes (aligned " << alignof(typename decltype(vectorKronecker)::Entry) << " bytes)"
+                      << "\n  CT Matrix Kronecker size: " << sizeof(typename decltype(matrixKronecker)::Entry) << " bytes (aligned " << alignof(typename decltype(matrixKronecker)::Entry) << " bytes)"
                       << "\n  ToffoliTable::Entry size: " << sizeof(ToffoliTable<mEdge>::Entry) << " bytes (aligned " << alignof(ToffoliTable<mEdge>::Entry) << " bytes)"
                       << "\n  Package size: " << sizeof(Package) << " bytes (aligned " << alignof(Package) << " bytes)"
                       << "\n"
@@ -2611,42 +2619,5 @@ namespace dd {
             cn.complexTable.printStatistics();
         }
     };
-
-    inline Package::vNode Package::vNode::terminalNode{{{{nullptr, Complex::zero}, {nullptr, Complex::zero}}},
-                                                       nullptr,
-                                                       0,
-                                                       -1};
-
-    inline Package::mNode Package::mNode::terminalNode{
-            {{{nullptr, Complex::zero}, {nullptr, Complex::zero}, {nullptr, Complex::zero}, {nullptr, Complex::zero}}},
-            nullptr,
-            0,
-            -1,
-            true,
-            true};
-
-    template<>
-    [[nodiscard]] inline UniqueTable<Package::vNode>& Package::getUniqueTable() { return vUniqueTable; }
-
-    template<>
-    [[nodiscard]] inline UniqueTable<Package::mNode>& Package::getUniqueTable() { return mUniqueTable; }
-
-    template<>
-    [[nodiscard]] inline ComputeTable<Package::vCachedEdge, Package::vCachedEdge, Package::vCachedEdge>& Package::getAddComputeTable() { return vectorAdd; }
-
-    template<>
-    [[nodiscard]] inline ComputeTable<Package::mCachedEdge, Package::mCachedEdge, Package::mCachedEdge>& Package::getAddComputeTable() { return matrixAdd; }
-
-    template<>
-    [[nodiscard]] inline ComputeTable<Package::mEdge, Package::vEdge, Package::vCachedEdge>& Package::getMultiplicationComputeTable() { return matrixVectorMultiplication; }
-
-    template<>
-    [[nodiscard]] inline ComputeTable<Package::mEdge, Package::mEdge, Package::mCachedEdge>& Package::getMultiplicationComputeTable() { return matrixMatrixMultiplication; }
-
-    template<>
-    [[nodiscard]] inline ComputeTable<Package::vEdge, Package::vEdge, Package::vCachedEdge, 4096>& Package::getKroneckerComputeTable() { return vectorKronecker; }
-
-    template<>
-    [[nodiscard]] inline ComputeTable<Package::mEdge, Package::mEdge, Package::mCachedEdge, 4096>& Package::getKroneckerComputeTable() { return matrixKronecker; }
 } // namespace dd
 #endif

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -12,7 +12,7 @@
 
 using namespace dd::literals;
 
-auto BellCicuit1(std::unique_ptr<dd::Package>& dd) {
+auto BellCicuit1(std::unique_ptr<dd::Package<>>& dd) {
     /***** define Hadamard gate acting on q0 *****/
     auto h_gate = dd->makeGateDD(dd::Hmat, 2, 0);
 
@@ -23,7 +23,7 @@ auto BellCicuit1(std::unique_ptr<dd::Package>& dd) {
     return dd->multiply(cx_gate, h_gate);
 }
 
-auto BellCicuit2(std::unique_ptr<dd::Package>& dd) {
+auto BellCicuit2(std::unique_ptr<dd::Package<>>& dd) {
     /***** define Hadamard gate acting on q1 *****/
     auto h_gate_q1 = dd->makeGateDD(dd::Hmat, 2, 1);
 
@@ -38,9 +38,9 @@ auto BellCicuit2(std::unique_ptr<dd::Package>& dd) {
 }
 
 int main() {
-    dd::Package::printInformation(); // uncomment to print various sizes of structs and arrays
+    dd::Package<>::printInformation(); // uncomment to print various sizes of structs and arrays
     //Initialize package
-    auto dd = std::make_unique<dd::Package>(4);
+    auto dd = std::make_unique<dd::Package<>>(4);
 
     // create Bell circuit 1
     auto bell_circuit1 = BellCicuit1(dd);

--- a/test/test_package.cpp
+++ b/test/test_package.cpp
@@ -16,11 +16,11 @@
 using namespace dd::literals;
 
 TEST(DDPackageTest, RequestInvalidPackageSize) {
-    EXPECT_THROW(auto dd = std::make_unique<dd::Package>(std::numeric_limits<dd::Qubit>::max() + 2), std::invalid_argument);
+    EXPECT_THROW(auto dd = std::make_unique<dd::Package<>>(std::numeric_limits<dd::Qubit>::max() + 2), std::invalid_argument);
 }
 
 TEST(DDPackageTest, OperationLookupTest) {
-    auto dd = std::make_unique<dd::Package>(1);
+    auto dd = std::make_unique<dd::Package<>>(1);
 
     // ATrue is not the operation that is being stored, but for the test it doesn't matter
     auto tmp_op = dd->noiseOperationTable.lookup(1, dd::NoiseOperationKind::ATrue, 0);
@@ -42,7 +42,7 @@ TEST(DDPackageTest, OperationLookupTest) {
 }
 
 TEST(DDPackageTest, TrivialTest) {
-    auto dd = std::make_unique<dd::Package>(2);
+    auto dd = std::make_unique<dd::Package<>>(2);
     EXPECT_EQ(dd->qubits(), 2);
 
     auto x_gate = dd->makeGateDD(dd::Xmat, 1, 0);
@@ -62,7 +62,7 @@ TEST(DDPackageTest, TrivialTest) {
 }
 
 TEST(DDPackageTest, BellState) {
-    auto dd = std::make_unique<dd::Package>(2);
+    auto dd = std::make_unique<dd::Package<>>(2);
 
     auto h_gate     = dd->makeGateDD(dd::Hmat, 2, 1);
     auto cx_gate    = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
@@ -105,7 +105,7 @@ TEST(DDPackageTest, BellState) {
 }
 
 TEST(DDPackageTest, QFTState) {
-    auto dd = std::make_unique<dd::Package>(3);
+    auto dd = std::make_unique<dd::Package<>>(3);
 
     auto h0_gate   = dd->makeGateDD(dd::Hmat, 3, 0);
     auto s0_gate   = dd->makeGateDD(dd::Smat, 3, 1_pc, 0);
@@ -166,7 +166,7 @@ TEST(DDPackageTest, QFTState) {
 }
 
 TEST(DDPackageTest, CorruptedBellState) {
-    auto dd = std::make_unique<dd::Package>(2);
+    auto dd = std::make_unique<dd::Package<>>(2);
 
     auto h_gate     = dd->makeGateDD(dd::Hmat, 2, 1);
     auto cx_gate    = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
@@ -187,7 +187,7 @@ TEST(DDPackageTest, CorruptedBellState) {
 }
 
 TEST(DDPackageTest, NegativeControl) {
-    auto dd = std::make_unique<dd::Package>(2);
+    auto dd = std::make_unique<dd::Package<>>(2);
 
     auto x_gate     = dd->makeGateDD(dd::Xmat, 2, 1_nc, 0);
     auto zero_state = dd->makeZeroState(2);
@@ -196,14 +196,14 @@ TEST(DDPackageTest, NegativeControl) {
 }
 
 TEST(DDPackageTest, IdentityTrace) {
-    auto dd        = std::make_unique<dd::Package>(4);
+    auto dd        = std::make_unique<dd::Package<>>(4);
     auto fullTrace = dd->trace(dd->makeIdent(4));
 
     ASSERT_EQ(fullTrace, (dd::ComplexValue{16, 0}));
 }
 
 TEST(DDPackageTest, PartialIdentityTrace) {
-    auto dd  = std::make_unique<dd::Package>(2);
+    auto dd  = std::make_unique<dd::Package<>>(2);
     auto tr  = dd->partialTrace(dd->makeIdent(2), {false, true});
     auto mul = dd->multiply(tr, tr);
     EXPECT_EQ(dd::CTEntry::val(mul.w.r), 4.0);
@@ -211,7 +211,7 @@ TEST(DDPackageTest, PartialIdentityTrace) {
 
 TEST(DDPackageTest, StateGenerationManipulation) {
     unsigned short nqubits = 6;
-    auto           dd      = std::make_unique<dd::Package>(nqubits);
+    auto           dd      = std::make_unique<dd::Package<>>(nqubits);
     auto           b       = std::vector<bool>(nqubits, false);
     b[0] = b[1] = true;
     auto e      = dd->makeBasisState(nqubits, b);
@@ -231,7 +231,7 @@ TEST(DDPackageTest, StateGenerationManipulation) {
 }
 
 TEST(DDPackageTest, VectorSerializationTest) {
-    auto dd = std::make_unique<dd::Package>(2);
+    auto dd = std::make_unique<dd::Package<>>(2);
 
     auto h_gate     = dd->makeGateDD(dd::Hmat, 2, 1);
     auto cx_gate    = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
@@ -240,16 +240,16 @@ TEST(DDPackageTest, VectorSerializationTest) {
     auto bell_state = dd->multiply(dd->multiply(cx_gate, h_gate), zero_state);
 
     serialize(bell_state, "bell_state.dd", false);
-    auto deserialized_bell_state = dd->deserialize<dd::Package::vNode>("bell_state.dd", false);
+    auto deserialized_bell_state = dd->deserialize<dd::vNode>("bell_state.dd", false);
     EXPECT_EQ(bell_state, deserialized_bell_state);
 
     serialize(bell_state, "bell_state_binary.dd", true);
-    deserialized_bell_state = dd->deserialize<dd::Package::vNode>("bell_state_binary.dd", true);
+    deserialized_bell_state = dd->deserialize<dd::vNode>("bell_state_binary.dd", true);
     EXPECT_EQ(bell_state, deserialized_bell_state);
 }
 
 TEST(DDPackageTest, BellMatrix) {
-    auto dd = std::make_unique<dd::Package>(2);
+    auto dd = std::make_unique<dd::Package<>>(2);
 
     auto h_gate  = dd->makeGateDD(dd::Hmat, 2, 1);
     auto cx_gate = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
@@ -302,7 +302,7 @@ TEST(DDPackageTest, BellMatrix) {
 }
 
 TEST(DDPackageTest, MatrixSerializationTest) {
-    auto dd = std::make_unique<dd::Package>(2);
+    auto dd = std::make_unique<dd::Package<>>(2);
 
     auto h_gate  = dd->makeGateDD(dd::Hmat, 2, 1);
     auto cx_gate = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
@@ -310,16 +310,16 @@ TEST(DDPackageTest, MatrixSerializationTest) {
     auto bell_matrix = dd->multiply(cx_gate, h_gate);
 
     serialize(bell_matrix, "bell_matrix.dd", false);
-    auto deserialized_bell_matrix = dd->deserialize<dd::Package::mNode>("bell_matrix.dd", false);
+    auto deserialized_bell_matrix = dd->deserialize<dd::mNode>("bell_matrix.dd", false);
     EXPECT_EQ(bell_matrix, deserialized_bell_matrix);
 
     serialize(bell_matrix, "bell_matrix_binary.dd", true);
-    deserialized_bell_matrix = dd->deserialize<dd::Package::mNode>("bell_matrix_binary.dd", true);
+    deserialized_bell_matrix = dd->deserialize<dd::mNode>("bell_matrix_binary.dd", true);
     EXPECT_EQ(bell_matrix, deserialized_bell_matrix);
 }
 
 TEST(DDPackageTest, SerializationErrors) {
-    auto dd = std::make_unique<dd::Package>(2);
+    auto dd = std::make_unique<dd::Package<>>(2);
 
     auto h_gate     = dd->makeGateDD(dd::Hmat, 2, 1);
     auto cx_gate    = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
@@ -328,44 +328,44 @@ TEST(DDPackageTest, SerializationErrors) {
 
     // test non-existing file
     EXPECT_THROW(serialize(bell_state, "./path/that/does/not/exist/filename.dd"), std::invalid_argument);
-    EXPECT_THROW(dd->deserialize<dd::Package::vNode>("./path/that/does/not/exist/filename.dd", true), std::invalid_argument);
+    EXPECT_THROW(dd->deserialize<dd::vNode>("./path/that/does/not/exist/filename.dd", true), std::invalid_argument);
 
     // test wrong version number
     std::stringstream ss{};
     ss << 2 << std::endl;
-    EXPECT_THROW(dd->deserialize<dd::Package::vNode>(ss, false), std::runtime_error);
+    EXPECT_THROW(dd->deserialize<dd::vNode>(ss, false), std::runtime_error);
     ss << 2 << std::endl;
-    EXPECT_THROW(dd->deserialize<dd::Package::mNode>(ss, false), std::runtime_error);
+    EXPECT_THROW(dd->deserialize<dd::mNode>(ss, false), std::runtime_error);
 
     ss.str("");
     std::remove_const_t<decltype(dd::SERIALIZATION_VERSION)> version = 2;
     ss.write(reinterpret_cast<const char*>(&version), sizeof(decltype(dd::SERIALIZATION_VERSION)));
-    EXPECT_THROW(dd->deserialize<dd::Package::vNode>(ss, true), std::runtime_error);
+    EXPECT_THROW(dd->deserialize<dd::vNode>(ss, true), std::runtime_error);
     ss.write(reinterpret_cast<const char*>(&version), sizeof(decltype(dd::SERIALIZATION_VERSION)));
-    EXPECT_THROW(dd->deserialize<dd::Package::mNode>(ss, true), std::runtime_error);
+    EXPECT_THROW(dd->deserialize<dd::mNode>(ss, true), std::runtime_error);
 
     // test wrong format
     ss.str("");
     ss << "1" << std::endl;
     ss << "not_complex" << std::endl;
-    EXPECT_THROW(dd->deserialize<dd::Package::vNode>(ss), std::runtime_error);
+    EXPECT_THROW(dd->deserialize<dd::vNode>(ss), std::runtime_error);
     ss << "1" << std::endl;
     ss << "not_complex" << std::endl;
-    EXPECT_THROW(dd->deserialize<dd::Package::mNode>(ss), std::runtime_error);
+    EXPECT_THROW(dd->deserialize<dd::mNode>(ss), std::runtime_error);
 
     ss.str("");
     ss << "1" << std::endl;
     ss << "1.0" << std::endl;
     ss << "no_node_here" << std::endl;
-    EXPECT_THROW(dd->deserialize<dd::Package::vNode>(ss), std::runtime_error);
+    EXPECT_THROW(dd->deserialize<dd::vNode>(ss), std::runtime_error);
     ss << "1" << std::endl;
     ss << "1.0" << std::endl;
     ss << "no_node_here" << std::endl;
-    EXPECT_THROW(dd->deserialize<dd::Package::mNode>(ss), std::runtime_error);
+    EXPECT_THROW(dd->deserialize<dd::mNode>(ss), std::runtime_error);
 }
 
 TEST(DDPackageTest, TestConsistency) {
-    auto dd = std::make_unique<dd::Package>(2);
+    auto dd = std::make_unique<dd::Package<>>(2);
 
     auto h_gate     = dd->makeGateDD(dd::Hmat, 2, 1);
     auto cx_gate    = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
@@ -389,7 +389,7 @@ TEST(DDPackageTest, TestConsistency) {
 }
 
 TEST(DDPackageTest, ToffoliTable) {
-    auto dd = std::make_unique<dd::Package>(4);
+    auto dd = std::make_unique<dd::Package<>>(4);
 
     // try to search for a toffoli in an empty table
     auto toffoli = dd->toffoliTable.lookup(3, {0_nc, 1_pc}, 2);
@@ -419,7 +419,7 @@ TEST(DDPackageTest, ToffoliTable) {
 }
 
 TEST(DDPackageTest, Extend) {
-    auto dd = std::make_unique<dd::Package>(4);
+    auto dd = std::make_unique<dd::Package<>>(4);
 
     auto id = dd->makeIdent(3);
     EXPECT_EQ(id.p->v, 2);
@@ -435,7 +435,7 @@ TEST(DDPackageTest, Extend) {
 }
 
 TEST(DDPackageTest, Identity) {
-    auto dd = std::make_unique<dd::Package>(4);
+    auto dd = std::make_unique<dd::Package<>>(4);
 
     EXPECT_TRUE(dd->makeIdent(0).isOneTerminal());
     EXPECT_TRUE(dd->makeIdent(0, -1).isOneTerminal());
@@ -457,7 +457,7 @@ TEST(DDPackageTest, Identity) {
 }
 
 TEST(DDPackageTest, TestLocalInconsistency) {
-    auto dd = std::make_unique<dd::Package>(3);
+    auto dd = std::make_unique<dd::Package<>>(3);
 
     auto h_gate     = dd->makeGateDD(dd::Hmat, 2, 0);
     auto cx_gate    = dd->makeGateDD(dd::Xmat, 2, 0_pc, 1);
@@ -484,7 +484,7 @@ TEST(DDPackageTest, TestLocalInconsistency) {
 }
 
 TEST(DDPackageTest, Ancillaries) {
-    auto dd          = std::make_unique<dd::Package>(4);
+    auto dd          = std::make_unique<dd::Package<>>(4);
     auto h_gate      = dd->makeGateDD(dd::Hmat, 2, 0);
     auto cx_gate     = dd->makeGateDD(dd::Xmat, 2, 0_pc, 1);
     auto bell_matrix = dd->multiply(cx_gate, h_gate);
@@ -521,7 +521,7 @@ TEST(DDPackageTest, Ancillaries) {
 }
 
 TEST(DDPackageTest, GarbageVector) {
-    auto dd         = std::make_unique<dd::Package>(4);
+    auto dd         = std::make_unique<dd::Package<>>(4);
     auto h_gate     = dd->makeGateDD(dd::Hmat, 2, 0);
     auto cx_gate    = dd->makeGateDD(dd::Xmat, 2, 0_pc, 1);
     auto zero_state = dd->makeZeroState(2);
@@ -551,7 +551,7 @@ TEST(DDPackageTest, GarbageVector) {
 }
 
 TEST(DDPackageTest, GarbageMatrix) {
-    auto dd          = std::make_unique<dd::Package>(4);
+    auto dd          = std::make_unique<dd::Package<>>(4);
     auto h_gate      = dd->makeGateDD(dd::Hmat, 2, 0);
     auto cx_gate     = dd->makeGateDD(dd::Xmat, 2, 0_pc, 1);
     auto bell_matrix = dd->multiply(cx_gate, h_gate);
@@ -584,7 +584,7 @@ TEST(DDPackageTest, GarbageMatrix) {
 
 TEST(DDPackageTest, InvalidMakeBasisStateAndGate) {
     auto nqubits    = 2;
-    auto dd         = std::make_unique<dd::Package>(nqubits);
+    auto dd         = std::make_unique<dd::Package<>>(nqubits);
     auto basisState = std::vector<dd::BasisStates>{dd::BasisStates::zero};
     EXPECT_THROW(dd->makeBasisState(nqubits, basisState), std::runtime_error);
     EXPECT_THROW(dd->makeZeroState(3), std::runtime_error);
@@ -594,13 +594,13 @@ TEST(DDPackageTest, InvalidMakeBasisStateAndGate) {
 }
 
 TEST(DDPackageTest, InvalidDecRef) {
-    auto dd = std::make_unique<dd::Package>(2);
+    auto dd = std::make_unique<dd::Package<>>(2);
     auto e  = dd->makeIdent(2);
     EXPECT_THROW(dd->decRef(e), std::runtime_error);
 }
 
 TEST(DDPackageTest, PackageReset) {
-    auto dd = std::make_unique<dd::Package>(1);
+    auto dd = std::make_unique<dd::Package<>>(1);
 
     // one node in unique table of variable 0
     auto        i_gate = dd->makeIdent(1);
@@ -621,7 +621,7 @@ TEST(DDPackageTest, PackageReset) {
 }
 
 TEST(DDPackageTest, MaxRefCount) {
-    auto dd = std::make_unique<dd::Package>(1);
+    auto dd = std::make_unique<dd::Package<>>(1);
     auto e  = dd->makeIdent(1);
     // ref count saturates at this value
     e.p->ref = std::numeric_limits<decltype(e.p->ref)>::max();
@@ -630,7 +630,7 @@ TEST(DDPackageTest, MaxRefCount) {
 }
 
 TEST(DDPackageTest, Inverse) {
-    auto dd   = std::make_unique<dd::Package>(1);
+    auto dd   = std::make_unique<dd::Package<>>(1);
     auto x    = dd->makeGateDD(dd::Xmat, 1, 0);
     auto xdag = dd->conjugateTranspose(x);
     EXPECT_EQ(x, xdag);
@@ -648,11 +648,11 @@ TEST(DDPackageTest, Inverse) {
 }
 
 TEST(DDPackageTest, UniqueTableAllocation) {
-    auto dd = std::make_unique<dd::Package>(1);
+    auto dd = std::make_unique<dd::Package<>>(1);
 
     auto allocs = dd->vUniqueTable.getAllocations();
     std::cout << allocs << std::endl;
-    std::vector<dd::Package::vNode*> nodes{allocs};
+    std::vector<dd::vNode*> nodes{allocs};
     // get all the nodes that are pre-allocated
     for (auto i = 0U; i < allocs; ++i) {
         nodes[i] = dd->vUniqueTable.getNode();
@@ -668,7 +668,7 @@ TEST(DDPackageTest, UniqueTableAllocation) {
 }
 
 TEST(DDPackageTest, MatrixTranspose) {
-    auto dd = std::make_unique<dd::Package>(2);
+    auto dd = std::make_unique<dd::Package<>>(2);
     auto cx = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
 
     // transposing a symmetric matrix shall yield a symmetric matrix
@@ -690,15 +690,15 @@ TEST(DDPackageTest, MatrixTranspose) {
 }
 
 TEST(DDPackageTest, SpecialCaseTerminal) {
-    auto dd  = std::make_unique<dd::Package>(2);
-    auto one = dd::Package::vEdge::one;
+    auto dd  = std::make_unique<dd::Package<>>(2);
+    auto one = dd::vEdge::one;
     dd::export2Dot(one, "oneColored.dot", true);
     dd::export2Dot(one, "oneClassic.dot", false);
     dd::export2Dot(one, "oneMemory.dot", true, true, false, true);
 
     EXPECT_EQ(dd->vUniqueTable.lookup(one), one);
 
-    auto zero = dd::Package::vEdge::zero;
+    auto zero = dd::vEdge::zero;
     EXPECT_EQ(dd->kronecker(zero, one), zero);
     EXPECT_EQ(dd->kronecker(one, one), one);
 
@@ -706,14 +706,14 @@ TEST(DDPackageTest, SpecialCaseTerminal) {
     dd::ComplexValue cOne{1.0, 0.0};
     EXPECT_EQ(dd->getValueByPath(one, ""), cOne);
     EXPECT_EQ(dd->getValueByPath(one, 0), cOne);
-    EXPECT_EQ(dd->getValueByPath(dd::Package::mEdge::one, 0, 0), cOne);
+    EXPECT_EQ(dd->getValueByPath(dd::mEdge::one, 0, 0), cOne);
 
     dd::ComplexValue cZero{0.0, 0.0};
     EXPECT_EQ(dd->innerProduct(zero, zero), cZero);
 }
 
 //TEST(DDPackageTest, GarbageCollectSomeButNotAll) {
-//    auto dd = std::make_unique<dd::Package>(1);
+//    auto dd = std::make_unique<dd::Package<>>(1);
 //
 //    // one node in unique table of variable 0
 //    const auto& unique = dd->mUniqueTable.getTables();
@@ -740,17 +740,17 @@ TEST(DDPackageTest, SpecialCaseTerminal) {
 //}
 
 TEST(DDPackageTest, KroneckerProduct) {
-    auto dd        = std::make_unique<dd::Package>(2);
+    auto dd        = std::make_unique<dd::Package<>>(2);
     auto X         = dd->makeGateDD(dd::Xmat, 1, 0);
     auto kronecker = dd->kronecker(X, X);
     EXPECT_EQ(kronecker.p->v, 1);
-    EXPECT_EQ(kronecker.p->e[0], dd::Package::mEdge::zero);
+    EXPECT_EQ(kronecker.p->e[0], dd::mEdge::zero);
     EXPECT_EQ(kronecker.p->e[0], kronecker.p->e[3]);
     EXPECT_EQ(kronecker.p->e[1], kronecker.p->e[2]);
     EXPECT_EQ(kronecker.p->e[1].p->v, 0);
-    EXPECT_EQ(kronecker.p->e[1].p->e[0], dd::Package::mEdge::zero);
+    EXPECT_EQ(kronecker.p->e[1].p->e[0], dd::mEdge::zero);
     EXPECT_EQ(kronecker.p->e[1].p->e[0], kronecker.p->e[1].p->e[3]);
-    EXPECT_EQ(kronecker.p->e[1].p->e[1], dd::Package::mEdge::one);
+    EXPECT_EQ(kronecker.p->e[1].p->e[1], dd::mEdge::one);
     EXPECT_EQ(kronecker.p->e[1].p->e[1], kronecker.p->e[1].p->e[2]);
 
     auto kronecker2 = dd->kronecker(X, X);
@@ -758,9 +758,9 @@ TEST(DDPackageTest, KroneckerProduct) {
 }
 
 TEST(DDPackageTest, NearZeroNormalize) {
-    auto               dd       = std::make_unique<dd::Package>(2);
-    dd::fp             nearZero = dd::ComplexTable<>::tolerance() / 10;
-    dd::Package::vEdge ve{};
+    auto      dd       = std::make_unique<dd::Package<>>(2);
+    dd::fp    nearZero = dd::ComplexTable<>::tolerance() / 10;
+    dd::vEdge ve{};
     ve.p    = dd->vUniqueTable.getNode();
     ve.p->v = 1;
     ve.w    = dd::Complex::one;
@@ -768,21 +768,21 @@ TEST(DDPackageTest, NearZeroNormalize) {
         edge.p    = dd->vUniqueTable.getNode();
         edge.p->v = 0;
         edge.w    = dd->cn.getCached(nearZero, 0.);
-        edge.p->e = {dd::Package::vEdge::one, dd::Package::vEdge::one};
+        edge.p->e = {dd::vEdge::one, dd::vEdge::one};
     }
     auto veNormalizedCached = dd->normalize(ve, true);
-    EXPECT_EQ(veNormalizedCached, dd::Package::vEdge::zero);
+    EXPECT_EQ(veNormalizedCached, dd::vEdge::zero);
 
     for (auto& edge: ve.p->e) {
         edge.p    = dd->vUniqueTable.getNode();
         edge.p->v = 0;
         edge.w    = dd->cn.lookup(nearZero, 0.);
-        edge.p->e = {dd::Package::vEdge::one, dd::Package::vEdge::one};
+        edge.p->e = {dd::vEdge::one, dd::vEdge::one};
     }
     auto veNormalized = dd->normalize(ve, false);
-    EXPECT_EQ(veNormalized, dd::Package::vEdge::zero);
+    EXPECT_EQ(veNormalized, dd::vEdge::zero);
 
-    dd::Package::mEdge me{};
+    dd::mEdge me{};
     me.p    = dd->mUniqueTable.getNode();
     me.p->v = 1;
     me.w    = dd::Complex::one;
@@ -790,19 +790,19 @@ TEST(DDPackageTest, NearZeroNormalize) {
         edge.p    = dd->mUniqueTable.getNode();
         edge.p->v = 0;
         edge.w    = dd->cn.getCached(nearZero, 0.);
-        edge.p->e = {dd::Package::mEdge::one, dd::Package::mEdge::one, dd::Package::mEdge::one, dd::Package::mEdge::one};
+        edge.p->e = {dd::mEdge::one, dd::mEdge::one, dd::mEdge::one, dd::mEdge::one};
     }
     auto meNormalizedCached = dd->normalize(me, true);
-    EXPECT_EQ(meNormalizedCached, dd::Package::mEdge::zero);
+    EXPECT_EQ(meNormalizedCached, dd::mEdge::zero);
 
     for (auto& edge: me.p->e) {
         edge.p    = dd->mUniqueTable.getNode();
         edge.p->v = 0;
         edge.w    = dd->cn.lookup(nearZero, 0.);
-        edge.p->e = {dd::Package::mEdge::one, dd::Package::mEdge::one, dd::Package::mEdge::one, dd::Package::mEdge::one};
+        edge.p->e = {dd::mEdge::one, dd::mEdge::one, dd::mEdge::one, dd::mEdge::one};
     }
     auto meNormalized = dd->normalize(me, false);
-    EXPECT_EQ(meNormalized, dd::Package::mEdge::zero);
+    EXPECT_EQ(meNormalized, dd::mEdge::zero);
 }
 
 TEST(DDPackageTest, Controls) {
@@ -819,7 +819,7 @@ TEST(DDPackageTest, Controls) {
 }
 
 TEST(DDPackageTest, DestructiveMeasurementAll) {
-    auto dd         = std::make_unique<dd::Package>(4);
+    auto dd         = std::make_unique<dd::Package<>>(4);
     auto hGate0     = dd->makeGateDD(dd::Hmat, 2, 0);
     auto hGate1     = dd->makeGateDD(dd::Hmat, 2, 1);
     auto plusMatrix = dd->multiply(hGate0, hGate1);
@@ -844,7 +844,7 @@ TEST(DDPackageTest, DestructiveMeasurementAll) {
 }
 
 TEST(DDPackageTest, DestructiveMeasurementOne) {
-    auto dd         = std::make_unique<dd::Package>(4);
+    auto dd         = std::make_unique<dd::Package<>>(4);
     auto hGate0     = dd->makeGateDD(dd::Hmat, 2, 0);
     auto hGate1     = dd->makeGateDD(dd::Hmat, 2, 1);
     auto plusMatrix = dd->multiply(hGate0, hGate1);
@@ -865,7 +865,7 @@ TEST(DDPackageTest, DestructiveMeasurementOne) {
 }
 
 TEST(DDPackageTest, DestructiveMeasurementOneArbitraryNormalization) {
-    auto dd         = std::make_unique<dd::Package>(4);
+    auto dd         = std::make_unique<dd::Package<>>(4);
     auto hGate0     = dd->makeGateDD(dd::Hmat, 2, 0);
     auto hGate1     = dd->makeGateDD(dd::Hmat, 2, 1);
     auto plusMatrix = dd->multiply(hGate0, hGate1);
@@ -1006,7 +1006,7 @@ TEST(DDPackageTest, BasicNumericInstabilityTest) {
 TEST(DDPackageTest, BasicNumericStabilityTest) {
     using limits = std::numeric_limits<dd::fp>;
 
-    auto dd  = std::make_unique<dd::Package>(1);
+    auto dd  = std::make_unique<dd::Package<>>(1);
     auto tol = dd::ComplexTable<>::tolerance();
     dd::ComplexNumbers::setTolerance(limits::epsilon());
     auto state  = dd->makeZeroState(1);
@@ -1031,7 +1031,7 @@ TEST(DDPackageTest, BasicNumericStabilityTest) {
 }
 
 TEST(DDPackageTest, NormalizationNumericStabilityTest) {
-    auto dd = std::make_unique<dd::Package>(1);
+    auto dd = std::make_unique<dd::Package<>>(1);
     for (std::size_t x = 23; x <= 50; ++x) {
         const auto lambda = dd::PI / static_cast<dd::fp>(1ULL << x);
         std::cout << std::setprecision(17) << "x: " << x << " | lambda: " << lambda << " | cos(lambda): " << std::cos(lambda) << " | sin(lambda): " << std::sin(lambda) << std::endl;
@@ -1044,7 +1044,7 @@ TEST(DDPackageTest, NormalizationNumericStabilityTest) {
 }
 
 TEST(DDPackageTest, FidelityOfMeasurementOutcomes) {
-    auto dd = std::make_unique<dd::Package>(3);
+    auto dd = std::make_unique<dd::Package<>>(3);
 
     auto h_gate     = dd->makeGateDD(dd::Hmat, 3, 2);
     auto cx_gate1   = dd->makeGateDD(dd::Xmat, 3, 2_pc, 1);
@@ -1061,28 +1061,28 @@ TEST(DDPackageTest, FidelityOfMeasurementOutcomes) {
 }
 
 TEST(DDPackageTest, CloseToIdentity) {
-    auto dd = std::make_unique<dd::Package>(3);
+    auto dd = std::make_unique<dd::Package<>>(3);
     auto id = dd->makeIdent(1);
     EXPECT_TRUE(dd->isCloseToIdentity(id));
-    dd::Package::mEdge close{};
+    dd::mEdge close{};
     close.p  = id.p;
     close.w  = dd->cn.lookup(1e-11, 0);
-    auto id2 = dd->makeDDNode(1, std::array{id, dd::Package::mEdge::zero, dd::Package::mEdge::zero, close});
+    auto id2 = dd->makeDDNode(1, std::array{id, dd::mEdge::zero, dd::mEdge::zero, close});
     EXPECT_TRUE(dd->isCloseToIdentity(id2));
 
-    auto noId = dd->makeDDNode(1, std::array{dd::Package::mEdge::zero, id, dd::Package::mEdge::zero, close});
+    auto noId = dd->makeDDNode(1, std::array{dd::mEdge::zero, id, dd::mEdge::zero, close});
     EXPECT_FALSE(dd->isCloseToIdentity(noId));
 
-    dd::Package::mEdge notClose{};
+    dd::mEdge notClose{};
     notClose.p = id.p;
     notClose.w = dd->cn.lookup(1e-9, 0);
-    auto noId2 = dd->makeDDNode(1, std::array{notClose, dd::Package::mEdge::zero, dd::Package::mEdge::zero, close});
+    auto noId2 = dd->makeDDNode(1, std::array{notClose, dd::mEdge::zero, dd::mEdge::zero, close});
     EXPECT_FALSE(dd->isCloseToIdentity(noId2));
 
-    auto noId3 = dd->makeDDNode(1, std::array{close, dd::Package::mEdge::zero, dd::Package::mEdge::zero, notClose});
+    auto noId3 = dd->makeDDNode(1, std::array{close, dd::mEdge::zero, dd::mEdge::zero, notClose});
     EXPECT_FALSE(dd->isCloseToIdentity(noId3));
 
-    auto notClose2 = dd->makeDDNode(0, std::array{dd::Package::mEdge::zero, dd::Package::mEdge::one, dd::Package::mEdge::one, dd::Package::mEdge::zero});
-    auto notClose3 = dd->makeDDNode(1, std::array{notClose2, dd::Package::mEdge::zero, dd::Package::mEdge::zero, notClose2});
+    auto notClose2 = dd->makeDDNode(0, std::array{dd::mEdge::zero, dd::mEdge::one, dd::mEdge::one, dd::mEdge::zero});
+    auto notClose3 = dd->makeDDNode(1, std::array{notClose2, dd::mEdge::zero, dd::mEdge::zero, notClose2});
     EXPECT_FALSE(dd->isCloseToIdentity(notClose3));
 }


### PR DESCRIPTION
This PR explores the possibilities of setting the template parameters of the unique and compute tables of a DD package by making them available as template parameters of the `Package` class.

At the moment this is only considered a draft and it is yet to be tested, what this change implies for the QFR as well as our top-level repositories.

One breaking change is that the `vNode` and `mNode` classes have been moved to a separate file which makes life with template parameters a little bit easier (otherwise each use of `vNode` would have do be prefixed with `Package<lots of arguments>::`).

This PR also refactors the generic getter functions for the unique and compute tables and implements them inline using `if constexpr`.