### PR TITLE
🐛 fix missing include

### DIFF
--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -40,6 +40,7 @@
 #include <random>
 #include <regex>
 #include <set>
+#include <stack>
 #include <stdexcept>
 #include <string>
 #include <type_traits>


### PR DESCRIPTION
This tiny PR fixes a missing include introduced in the latest PR.