### PR TITLE
🔧 Reduce dependabot frequency for submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,7 @@ updates:
     directory: "/"
     # Check the submodules for updates every month
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
       time: "06:00"
       timezone: "Europe/Vienna"
     assignees:


### PR DESCRIPTION
We do not actively depend on updates of the `googletest` and `benchmark` submodules. As such, they create a lot of noise every week via dependabot updates for little to no benefit. This propagates through all of our repositories via the QFR and is amplified by both repositories "living at head".

This PR reduces the dependabot frequency for submodules to monthly (from weekly) in order to reduce the number of PRs created throughout our tools each week.