### PR TITLE
Integrate Clang-Tidy Workflow for DD Package

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,70 @@
+FormatStyle: file
+
+Checks: |
+  clang-diagnostic-*,
+  clang-analyzer-*,
+  boost-*,
+  bugprone-*,
+  -bugprone-easily-swappable-parameters,
+  clang-analyzer-*,
+  cppcoreguidelines-*,
+  -cppcoreguidelines-non-private-member-variables-in-classes,
+  -cppcoreguidelines-special-member-functions,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-macro-usage,
+  google-*,
+  -google-readability-todo,
+  -google-build-using-namespace,
+  misc-*,
+  -misc-no-recursion,
+  -misc-non-private-member-variables-in-classes,
+  modernize-*,
+  -modernize-use-trailing-return-type,
+  performance-*,
+  portability-*,
+  readability-*,
+  -readability-identifier-length,
+  -readability-magic-numbers,
+  -readability-function-cognitive-complexity
+
+CheckOptions:
+  - key: readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key: readability-identifier-naming.ClassIgnoredRegexp
+    value: ".*ZX.*|.*SWAP.*|.*CEX.*|.*DD.*|.*EQ.*"
+  - key: readability-identifier-naming.ConstantParameterCase
+    value: camelBack
+  - key: readability-identifier-naming.EnumCase
+    value: CamelCase
+  - key: readability-identifier-naming.EnumConstantCase
+    value: CamelCase
+  - key: readability-identifier-naming.FunctionCase
+    value: camelBack
+  - key: readability-identifier-naming.FunctionIgnoredRegexp
+    value: ".*ZX.*|.*SWAP.*|.*CEX.*|.*DD.*|.*EQ.*"
+  - key: readability-identifier-naming.GlobalConstantCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.IgnoreMainLikeFunctions
+    value: "true"
+  - key: readability-identifier-naming.LocalConstantCase
+    value: camelBack
+  - key: readability-identifier-naming.LocalVariableCase
+    value: camelBack
+  - key: readability-identifier-naming.MemberCase
+    value: camelBack
+  - key: readability-identifier-naming.MemberIgnoredRegexp
+    value: ".*ZX.*|.*SWAP.*|.*CEX.*|.*DD.*|.*EQ.*"
+  - key: readability-identifier-naming.MethodCase
+    value: camelBack
+  - key: readability-identifier-naming.ParameterCase
+    value: camelBack
+  - key: readability-identifier-naming.ParameterIgnoredRegexp
+    value: ".*ZX.*|.*SWAP.*|.*CEX.*|.*DD.*|.*EQ.*"
+  - key: readability-identifier-naming.NamespaceCase
+    value: lower_case
+  - key: readability-identifier-naming.StaticConstantCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.StructCase
+    value: CamelCase
+  - key: readability-identifier-naming.VariableCase
+    value: camelBack

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,6 +23,7 @@ Checks: |
   modernize-*,
   -modernize-use-trailing-return-type,
   performance-*,
+  -performance-no-int-to-ptr
   portability-*,
   readability-*,
   -readability-identifier-length,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,4 @@
 FormatStyle: file
-HeaderFilterRegex: '.*'
 
 Checks: |
   clang-diagnostic-*,
@@ -14,6 +13,7 @@ Checks: |
   -cppcoreguidelines-avoid-magic-numbers,
   -cppcoreguidelines-macro-usage,
   -cppcoreguidelines-pro-type-reinterpret-cast,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
   google-*,
   -google-readability-todo,
   -google-build-using-namespace,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,6 +12,7 @@ Checks: |
   -cppcoreguidelines-special-member-functions,
   -cppcoreguidelines-avoid-magic-numbers,
   -cppcoreguidelines-macro-usage,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
   google-*,
   -google-readability-todo,
   -google-build-using-namespace,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,5 @@
 FormatStyle: file
+HeaderFilterRegex: '.*'
 
 Checks: |
   clang-diagnostic-*,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,7 +23,7 @@ Checks: |
   modernize-*,
   -modernize-use-trailing-return-type,
   performance-*,
-  -performance-no-int-to-ptr
+  -performance-no-int-to-ptr,
   portability-*,
   readability-*,
   -readability-identifier-length,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,17 +84,6 @@ jobs:
           fail_ci_if_error: true
           verbose: true
 
-  codestyle:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: recursive
-      - uses: DoozyX/clang-format-lint-action@v0.14
-        with:
-          source:             'include test'
-          clangFormatVersion: 12
-
   benchmark:
     needs:   test
     runs-on: ubuntu-latest

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           submodules: recursive
       - name: Generate compilation database
-        run: CXX=clang++-14 cmake -S . -B build -DBUILD_DD_PACKAGE_TESTS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+        run: CC=clang-14 CXX=clang++-14 cmake -S . -B build -DBUILD_DD_PACKAGE_TESTS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
       - uses: cpp-linter/cpp-linter-action@v2
         id: linter
         env:

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -21,26 +21,17 @@ jobs:
           submodules: recursive
       - name: Generate compilation database
         run: CXX=clang++-14 cmake -S . -B build -DBUILD_DD_PACKAGE_TESTS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-      - uses: actions/setup-python@v4
-        name: Install Python
-        with:
-          python-version: "3.9"
-      - name: Install linter python package
-        run: python3 -m pip install git+https://github.com/cpp-linter/cpp-linter-action@v1
-      - name: Run linter
+      - uses: cpp-linter/cpp-linter-action@v2
         id: linter
-        run: |
-          cpp-linter \
-          --version=14 \
-          --style=file \
-          --tidy-checks='' \
-          --lines-changed-only=false \
-          --files-changed-only=false \
-          --thread-comments=true \
-          --ignore=build \
-          --database=build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          version: 14
+          style: file
+          tidy-checks: ""
+          thread-comments: true
+          ignore: build
+          database: build
       - name: Fail if linter found errors
         if: steps.linter.outputs.checks-failed > 0
         run: echo "Linter found errors" && exit 1

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -33,7 +33,7 @@ jobs:
           --style="file" \
           --tidy-checks="" \
           --thread-comments=true \
-          --files-changed-only=false \
+          --files-changed-only=true \
           --ignore="build" \
           --database=build \
           --extra-arg=-std=c++17

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pipx run --spec git+https://github.com/cpp-linter/cpp-linter@tidy-extra-args cpp-linter \
+          pipx run cpp-linter \
           --version=14 \
           --style="file" \
           --tidy-checks="" \

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -1,0 +1,46 @@
+name: cpp-linter
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cpp-linter:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Generate compilation database
+        run: CXX=clang++-14 cmake -S . -B build -DBUILD_DD_PACKAGE_TESTS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+      - uses: actions/setup-python@v4
+        name: Install Python
+        with:
+          python-version: "3.9"
+      - name: Install linter python package
+        run: python3 -m pip install git+https://github.com/cpp-linter/cpp-linter-action@v1
+      - name: Run linter
+        id: linter
+        run: |
+          cpp-linter \
+          --version=14 \
+          --style=file \
+          --tidy-checks='' \
+          --lines-changed-only=false \
+          --files-changed-only=false \
+          --thread-comments=true \
+          --ignore=build \
+          --database=build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fail if linter found errors
+        if: steps.linter.outputs.checks-failed > 0
+        run: echo "Linter found errors" && exit 1

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -21,18 +21,19 @@ jobs:
           submodules: recursive
       - name: Generate compilation database
         run: CC=clang-14 CXX=clang++-14 cmake -S . -B build -DBUILD_DD_PACKAGE_TESTS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-      - uses: cpp-linter/cpp-linter-action@v2
+      - name: Run cpp-linter
         id: linter
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          version: 14
-          style: file
-          tidy-checks: ""
-          thread-comments: true
-          files-changed-only: false
-          ignore: build
-          database: build
+        run: |
+          pipx run cpp-linter \
+          --version=14 \
+          --style="file" \
+          --tidy-checks="" \
+          --thread-comments=true \
+          --files-changed-only=false \
+          --ignore="build" \
+          --database=build
       - name: Fail if linter found errors
         if: steps.linter.outputs.checks-failed > 0
         run: echo "Linter found errors" && exit 1

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -28,14 +28,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pipx run cpp-linter \
+          pipx run --spec git+https://github.com/cpp-linter/cpp-linter@tidy-extra-args cpp-linter \
           --version=14 \
           --style="file" \
           --tidy-checks="" \
           --thread-comments=true \
           --files-changed-only=false \
           --ignore="build" \
-          --database=build
+          --database=build \
+          --extra-arg=-std=c++17
       - name: Fail if linter found errors
         if: steps.linter.outputs.checks-failed > 0
         run: echo "Linter found errors" && exit 1

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -30,6 +30,7 @@ jobs:
           style: file
           tidy-checks: ""
           thread-comments: true
+          files-changed-only: false
           ignore: build
           database: build
       - name: Fail if linter found errors

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -21,6 +21,8 @@ jobs:
           submodules: recursive
       - name: Generate compilation database
         run: CC=clang-14 CXX=clang++-14 cmake -S . -B build -DBUILD_DD_PACKAGE_TESTS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+      - name: Show compile commands
+        run: cat build/compile_commands.json
       - name: Run cpp-linter
         id: linter
         env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # set required cmake version
-cmake_minimum_required(VERSION 3.14...3.19)
+cmake_minimum_required(VERSION 3.14...3.23)
 
 # project definition
 project(DDPackage

--- a/include/dd/Complex.hpp
+++ b/include/dd/Complex.hpp
@@ -70,8 +70,8 @@ namespace dd {
         return os << c.toString();
     }
 
-    inline Complex Complex::zero{&ComplexTable<>::zero, &ComplexTable<>::zero};
-    inline Complex Complex::one{&ComplexTable<>::one, &ComplexTable<>::zero};
+    inline Complex Complex::zero{&ComplexTable<>::zero, &ComplexTable<>::zero}; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+    inline Complex Complex::one{&ComplexTable<>::one, &ComplexTable<>::zero};   // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 } // namespace dd
 
 namespace std {

--- a/include/dd/Complex.hpp
+++ b/include/dd/Complex.hpp
@@ -20,8 +20,8 @@ namespace dd {
         CTEntry* r;
         CTEntry* i;
 
-        static Complex zero;
-        static Complex one;
+        static const Complex zero; // NOLINT(readability-identifier-naming) automatic renaming does not work reliably, so skip linting
+        static const Complex one; // NOLINT(readability-identifier-naming) automatic renaming does not work reliably, so skip linting
 
         void setVal(const Complex& c) const {
             r->value = CTEntry::val(c.r);
@@ -70,8 +70,8 @@ namespace dd {
         return os << c.toString();
     }
 
-    inline Complex Complex::zero{&ComplexTable<>::zero, &ComplexTable<>::zero};
-    inline Complex Complex::one{&ComplexTable<>::one, &ComplexTable<>::zero};
+    const inline Complex Complex::zero{&ComplexTable<>::zero, &ComplexTable<>::zero};
+    const inline Complex Complex::one{&ComplexTable<>::one, &ComplexTable<>::zero};
 } // namespace dd
 
 namespace std {

--- a/include/dd/Complex.hpp
+++ b/include/dd/Complex.hpp
@@ -21,7 +21,7 @@ namespace dd {
         CTEntry* i;
 
         static const Complex zero; // NOLINT(readability-identifier-naming) automatic renaming does not work reliably, so skip linting
-        static const Complex one; // NOLINT(readability-identifier-naming) automatic renaming does not work reliably, so skip linting
+        static const Complex one;  // NOLINT(readability-identifier-naming) automatic renaming does not work reliably, so skip linting
 
         void setVal(const Complex& c) const {
             r->value = CTEntry::val(c.r);

--- a/include/dd/Complex.hpp
+++ b/include/dd/Complex.hpp
@@ -20,8 +20,8 @@ namespace dd {
         CTEntry* r;
         CTEntry* i;
 
-        static const Complex zero; // NOLINT(readability-identifier-naming) automatic renaming does not work reliably, so skip linting
-        static const Complex one;  // NOLINT(readability-identifier-naming) automatic renaming does not work reliably, so skip linting
+        static Complex zero; // NOLINT(readability-identifier-naming,cppcoreguidelines-avoid-non-const-global-variables) automatic renaming does not work reliably, so skip linting
+        static Complex one;  // NOLINT(readability-identifier-naming,cppcoreguidelines-avoid-non-const-global-variables) automatic renaming does not work reliably, so skip linting
 
         void setVal(const Complex& c) const {
             r->value = CTEntry::val(c.r);
@@ -70,8 +70,8 @@ namespace dd {
         return os << c.toString();
     }
 
-    const inline Complex Complex::zero{&ComplexTable<>::zero, &ComplexTable<>::zero};
-    const inline Complex Complex::one{&ComplexTable<>::one, &ComplexTable<>::zero};
+    inline Complex Complex::zero{&ComplexTable<>::zero, &ComplexTable<>::zero};
+    inline Complex Complex::one{&ComplexTable<>::one, &ComplexTable<>::zero};
 } // namespace dd
 
 namespace std {

--- a/include/dd/ComplexCache.hpp
+++ b/include/dd/ComplexCache.hpp
@@ -20,8 +20,7 @@ namespace dd {
         using Entry = ComplexTable<>::Entry;
 
     public:
-        ComplexCache():
-            chunkID(0), allocationSize(INITIAL_ALLOCATION_SIZE) {
+        ComplexCache(): allocationSize(INITIAL_ALLOCATION_SIZE) {
             // allocate first chunk of cache entries
             chunks.emplace_back(allocationSize);
             allocations += allocationSize;
@@ -120,7 +119,7 @@ namespace dd {
     private:
         Entry*                                available{};
         std::vector<std::vector<Entry>>       chunks{};
-        std::size_t                           chunkID;
+        std::size_t                           chunkID{0};
         typename std::vector<Entry>::iterator chunkIt;
         typename std::vector<Entry>::iterator chunkEndIt;
         std::size_t                           allocationSize;

--- a/include/dd/ComplexCache.hpp
+++ b/include/dd/ComplexCache.hpp
@@ -20,7 +20,8 @@ namespace dd {
         using Entry = ComplexTable<>::Entry;
 
     public:
-        ComplexCache(): allocationSize(INITIAL_ALLOCATION_SIZE) {
+        ComplexCache():
+            allocationSize(INITIAL_ALLOCATION_SIZE) {
             // allocate first chunk of cache entries
             chunks.emplace_back(allocationSize);
             allocations += allocationSize;

--- a/include/dd/ComplexNumbers.hpp
+++ b/include/dd/ComplexNumbers.hpp
@@ -153,8 +153,8 @@ namespace dd {
         Complex lookup(const fp& r, const fp& i) {
             Complex ret{};
 
-            auto sign_r = std::signbit(r);
-            if (sign_r) {
+            auto signR = std::signbit(r);
+            if (signR) {
                 auto absr = std::abs(r);
                 // if absolute value is close enough to zero, just return the zero entry (avoiding -0.0)
                 if (absr < decltype(complexTable)::tolerance()) {
@@ -166,8 +166,8 @@ namespace dd {
                 ret.r = complexTable.lookup(r);
             }
 
-            auto sign_i = std::signbit(i);
-            if (sign_i) {
+            auto signI = std::signbit(i);
+            if (signI) {
                 auto absi = std::abs(i);
                 // if absolute value is close enough to zero, just return the zero entry (avoiding -0.0)
                 if (absi < decltype(complexTable)::tolerance()) {

--- a/include/dd/ComplexTable.hpp
+++ b/include/dd/ComplexTable.hpp
@@ -105,9 +105,9 @@ namespace dd {
             }
         };
 
-        static const inline Entry zero{0., nullptr, 1};         // NOLINT(readability-identifier-naming) automatic renaming does not work reliably, so skip linting
-        static const inline Entry sqrt2_2{SQRT2_2, nullptr, 1}; // NOLINT(readability-identifier-naming) automatic renaming does not work reliably, so skip linting
-        static const inline Entry one{1., nullptr, 1};          // NOLINT(readability-identifier-naming) automatic renaming does not work reliably, so skip linting
+        static inline Entry zero{0., nullptr, 1};         // NOLINT(readability-identifier-naming,cppcoreguidelines-avoid-non-const-global-variables) automatic renaming does not work reliably, so skip linting
+        static inline Entry sqrt2_2{SQRT2_2, nullptr, 1}; // NOLINT(readability-identifier-naming,cppcoreguidelines-avoid-non-const-global-variables) automatic renaming does not work reliably, so skip linting
+        static inline Entry one{1., nullptr, 1};          // NOLINT(readability-identifier-naming,cppcoreguidelines-avoid-non-const-global-variables) automatic renaming does not work reliably, so skip linting
 
         ComplexTable():
             allocationSize(INITIAL_ALLOCATION_SIZE), gcLimit(INITIAL_GC_LIMIT) {

--- a/include/dd/ComplexTable.hpp
+++ b/include/dd/ComplexTable.hpp
@@ -82,7 +82,7 @@ namespace dd {
                 return left == right || approximatelyEquals(val(left), val(right));
             }
             [[nodiscard]] static constexpr bool approximatelyEquals(const fp left, const fp right) {
-                // NOLINTNTEXTLINE(clang-diagnostic-float-equal) equivalence check is a shortcut before check with tolerance
+                // NOLINTNEXTLINE(clang-diagnostic-float-equal) equivalence check is a shortcut before check with tolerance
                 return left == right || std::abs(left - right) <= TOLERANCE;
             }
 

--- a/include/dd/ComplexTable.hpp
+++ b/include/dd/ComplexTable.hpp
@@ -109,14 +109,7 @@ namespace dd {
         static inline Entry sqrt2_2{SQRT2_2, nullptr, 1}; // NOLINT(readability-identifier-naming,cppcoreguidelines-avoid-non-const-global-variables) automatic renaming does not work reliably, so skip linting
         static inline Entry one{1., nullptr, 1};          // NOLINT(readability-identifier-naming,cppcoreguidelines-avoid-non-const-global-variables) automatic renaming does not work reliably, so skip linting
 
-        ComplexTable():
-            allocationSize(INITIAL_ALLOCATION_SIZE), gcLimit(INITIAL_GC_LIMIT) {
-            // allocate first chunk of numbers
-            chunks.emplace_back(allocationSize);
-            allocations += allocationSize;
-            allocationSize *= GROWTH_FACTOR;
-            chunkIt    = chunks[0].begin();
-            chunkEndIt = chunks[0].end();
+        ComplexTable() {
             // add 1/2 to the complex table and increase its ref count (so that it is not collected)
             lookup(0.5L)->refCount++;
         }
@@ -503,13 +496,13 @@ namespace dd {
         static inline fp TOLERANCE = std::numeric_limits<dd::fp>::epsilon() * 1024; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
         Entry*                                available{};
-        std::vector<std::vector<Entry>>       chunks{};
+        std::vector<std::vector<Entry>>       chunks{INITIAL_ALLOCATION_SIZE};
         std::size_t                           chunkID{};
-        typename std::vector<Entry>::iterator chunkIt;
-        typename std::vector<Entry>::iterator chunkEndIt;
-        std::size_t                           allocationSize;
+        typename std::vector<Entry>::iterator chunkIt{chunks.at(0).begin()};
+        typename std::vector<Entry>::iterator chunkEndIt{chunks.at(0).end()};
+        std::size_t                           allocationSize{INITIAL_ALLOCATION_SIZE*GROWTH_FACTOR};
 
-        std::size_t allocations = 0;
+        std::size_t allocations = INITIAL_ALLOCATION_SIZE;
         std::size_t count       = 0;
         std::size_t peakCount   = 0;
 

--- a/include/dd/ComplexTable.hpp
+++ b/include/dd/ComplexTable.hpp
@@ -496,7 +496,7 @@ namespace dd {
         static inline fp TOLERANCE = std::numeric_limits<dd::fp>::epsilon() * 1024; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
         Entry*                                available{};
-        std::vector<std::vector<Entry>>       chunks{INITIAL_ALLOCATION_SIZE};
+        std::vector<std::vector<Entry>>       chunks{1, std::vector<Entry>{INITIAL_ALLOCATION_SIZE}};
         std::size_t                           chunkID{};
         typename std::vector<Entry>::iterator chunkIt{chunks.at(0).begin()};
         typename std::vector<Entry>::iterator chunkEndIt{chunks.at(0).end()};

--- a/include/dd/ComplexValue.hpp
+++ b/include/dd/ComplexValue.hpp
@@ -61,13 +61,15 @@ namespace dd {
 
             imag_str.erase(remove(imag_str.begin(), imag_str.end(), ' '), imag_str.end());
             imag_str.erase(remove(imag_str.begin(), imag_str.end(), 'i'), imag_str.end());
-            if (imag_str == "+" || imag_str == "-") imag_str = imag_str + "1";
+            if (imag_str == "+" || imag_str == "-") {
+                imag_str = imag_str + "1";
+            }
             fp imag = imag_str.empty() ? 0. : std::stod(imag_str);
             r       = {real};
             i       = {imag};
         }
 
-        static auto getLowestFraction(const double x, const std::uint64_t maxDenominator = std::uint64_t(1) << 10, const fp tol = dd::ComplexTable<>::tolerance()) {
+        static auto getLowestFraction(const double x, const std::uint64_t maxDenominator = static_cast<std::uint64_t>(1) << 10, const fp tol = dd::ComplexTable<>::tolerance()) {
             assert(x >= 0.);
 
             std::pair<std::uint64_t, std::uint64_t> lowerBound{0U, 1U};
@@ -80,12 +82,13 @@ namespace dd {
                 if (std::abs(x - median) <= tol) {
                     if (den <= maxDenominator) {
                         return std::pair{num, den};
-                    } else if (upperBound.second > lowerBound.second) {
-                        return upperBound;
-                    } else {
-                        return lowerBound;
                     }
-                } else if (x > median) {
+                    if (upperBound.second > lowerBound.second) {
+                        return upperBound;
+                    }
+                    return lowerBound;
+                }
+                if (x > median) {
                     lowerBound = {num, den};
                 } else {
                     upperBound = {num, den};
@@ -93,9 +96,8 @@ namespace dd {
             }
             if (lowerBound.second > maxDenominator) {
                 return upperBound;
-            } else {
-                return lowerBound;
             }
+            return lowerBound;
         }
 
         static void printFormatted(std::ostream& os, fp num, bool imaginary = false) {
@@ -176,10 +178,14 @@ namespace dd {
         static std::string toString(const fp& real, const fp& imag, bool formatted = true, int precision = -1) {
             std::ostringstream ss{};
 
-            if (precision >= 0) ss << std::setprecision(precision);
+            if (precision >= 0) {
+                ss << std::setprecision(precision);
+            }
             const auto tol = ComplexTable<>::tolerance();
 
-            if (std::abs(real) <= tol && std::abs(imag) <= tol) return "0";
+            if (std::abs(real) <= tol && std::abs(imag) <= tol) {
+                return "0";
+            }
 
             if (std::abs(real) > tol) {
                 if (formatted) {
@@ -193,7 +199,8 @@ namespace dd {
                     if (std::abs(real - imag) <= tol) {
                         ss << "(1+i)";
                         return ss.str();
-                    } else if (std::abs(real + imag) <= tol) {
+                    }
+                    if (std::abs(real + imag) <= tol) {
                         ss << "(1-i)";
                         return ss.str();
                     }

--- a/include/dd/ComplexValue.hpp
+++ b/include/dd/ComplexValue.hpp
@@ -39,6 +39,7 @@ namespace dd {
         }
 
         constexpr bool operator==(const ComplexValue& other) const {
+            // NOLINTNEXTLINE(clang-diagnostic-float-equal)
             return r == other.r && i == other.i;
         }
 
@@ -56,15 +57,15 @@ namespace dd {
             os.write(reinterpret_cast<const char*>(&i), sizeof(decltype(i)));
         }
 
-        void from_string(const std::string& real_str, std::string imag_str) {
-            fp real = real_str.empty() ? 0. : std::stod(real_str);
+        void fromString(const std::string& realStr, std::string imagStr) {
+            fp real = realStr.empty() ? 0. : std::stod(realStr);
 
-            imag_str.erase(remove(imag_str.begin(), imag_str.end(), ' '), imag_str.end());
-            imag_str.erase(remove(imag_str.begin(), imag_str.end(), 'i'), imag_str.end());
-            if (imag_str == "+" || imag_str == "-") {
-                imag_str = imag_str + "1";
+            imagStr.erase(remove(imagStr.begin(), imagStr.end(), ' '), imagStr.end());
+            imagStr.erase(remove(imagStr.begin(), imagStr.end(), 'i'), imagStr.end());
+            if (imagStr == "+" || imagStr == "-") {
+                imagStr = imagStr + "1";
             }
-            fp imag = imag_str.empty() ? 0. : std::stod(imag_str);
+            fp imag = imagStr.empty() ? 0. : std::stod(imagStr);
             r       = {real};
             i       = {imag};
         }

--- a/include/dd/ComplexValue.hpp
+++ b/include/dd/ComplexValue.hpp
@@ -70,7 +70,7 @@ namespace dd {
             i       = {imag};
         }
 
-        static auto getLowestFraction(const double x, const std::uint64_t maxDenominator = static_cast<std::uint64_t>(1) << 10, const fp tol = dd::ComplexTable<>::tolerance()) {
+        static auto getLowestFraction(const double x, const std::uint64_t maxDenominator = 1U << 10, const fp tol = dd::ComplexTable<>::tolerance()) {
             assert(x >= 0.);
 
             std::pair<std::uint64_t, std::uint64_t> lowerBound{0U, 1U};

--- a/include/dd/ComputeTable.hpp
+++ b/include/dd/ComputeTable.hpp
@@ -55,13 +55,21 @@ namespace dd {
             lookups++;
             const auto key   = hash(leftOperand, rightOperand);
             auto&      entry = table[key];
-            if (entry.result.p == nullptr) return result;
-            if (entry.leftOperand != leftOperand) return result;
-            if (entry.rightOperand != rightOperand) return result;
+            if (entry.result.p == nullptr) {
+                return result;
+            }
+            if (entry.leftOperand != leftOperand) {
+                return result;
+            }
+            if (entry.rightOperand != rightOperand) {
+                return result;
+            }
 
             if constexpr (std::is_same_v<RightOperandType, dEdge>) {
                 // Since density matrices are reduced representations of matrices, a density matrix may not be returned when a matrix is required and vice versa
-                if (dNode::isDensityMatrixNode(entry.result.p->flags) != useDensityMatrix) return result;
+                if (dNode::isDensityMatrixNode(entry.result.p->flags) != useDensityMatrix) {
+                    return result;
+                }
             }
             hits++;
             return entry.result;
@@ -69,8 +77,9 @@ namespace dd {
 
         void clear() {
             if (count > 0) {
-                for (auto& entry: table)
+                for (auto& entry: table) {
                     entry.result.p = nullptr;
+                }
                 count = 0;
             }
         }

--- a/include/dd/ComputeTable.hpp
+++ b/include/dd/ComputeTable.hpp
@@ -85,7 +85,8 @@ namespace dd {
         }
 
         [[nodiscard]] fp hitRatio() const { return static_cast<fp>(hits) / lookups; }
-        std::ostream&    printStatistics(std::ostream& os = std::cout) {
+
+        std::ostream& printStatistics(std::ostream& os = std::cout) {
             os << "hits: " << hits << ", looks: " << lookups << ", ratio: " << hitRatio() << std::endl;
             return os;
         }

--- a/include/dd/Control.hpp
+++ b/include/dd/Control.hpp
@@ -12,8 +12,8 @@
 
 namespace dd {
     struct Control {
-        enum class Type : bool { pos = true,
-                                 neg = false };
+        enum class Type : bool { pos = true,    // NOLINT(readability-identifier-naming)
+                                 neg = false }; // NOLINT(readability-identifier-naming)
 
         Qubit qubit{};
         Type  type = Type::pos;
@@ -33,7 +33,7 @@ namespace dd {
 
     // this allows a set of controls to be indexed by a `Qubit`
     struct CompareControl {
-        using is_transparent = void;
+        using is_transparent [[maybe_unused]] = void;
 
         inline bool operator()(const Control& lhs, const Control& rhs) const {
             return lhs < rhs;
@@ -50,8 +50,14 @@ namespace dd {
     using Controls = std::set<Control, CompareControl>;
 
     inline namespace literals {
-        inline Control operator""_pc(unsigned long long int q) { return {static_cast<Qubit>(q)}; }
-        inline Control operator""_nc(unsigned long long int q) { return {static_cast<Qubit>(q), Control::Type::neg}; }
+        // NOLINTNEXTLINE(google-runtime-int) User-defined literals require unsigned long long int
+        inline Control operator""_pc(unsigned long long int q) {
+            return {static_cast<Qubit>(q)};
+        }
+        // NOLINTNEXTLINE(google-runtime-int) User-defined literals require unsigned long long int
+        inline Control operator""_nc(unsigned long long int q) {
+            return {static_cast<Qubit>(q), Control::Type::neg};
+        }
     } // namespace literals
 } // namespace dd
 

--- a/include/dd/Definitions.hpp
+++ b/include/dd/Definitions.hpp
@@ -88,12 +88,14 @@ namespace dd {
 
     // calculates the Units in Last Place (ULP) distance of two floating point numbers
     [[maybe_unused]] static std::size_t ulpDistance(fp a, fp b) {
+        // NOLINTNEXTLINE(clang-diagnostic-float-equal)
         if (a == b) {
             return 0;
         }
 
         std::size_t ulps   = 1;
         fp          nextFP = std::nextafter(a, b);
+        // NOLINTNEXTLINE(clang-diagnostic-float-equal)
         while (nextFP != b) {
             ulps++;
             nextFP = std::nextafter(nextFP, b);

--- a/include/dd/Definitions.hpp
+++ b/include/dd/Definitions.hpp
@@ -38,12 +38,12 @@ namespace dd {
     static constexpr std::uint_fast8_t NEDGE = RADIX * RADIX;
 
     enum class BasisStates {
-        zero,
-        one,
-        plus,
-        minus,
-        right,
-        left
+        zero,  // NOLINT(readability-identifier-naming)
+        one,   // NOLINT(readability-identifier-naming)
+        plus,  // NOLINT(readability-identifier-naming)
+        minus, // NOLINT(readability-identifier-naming)
+        right, // NOLINT(readability-identifier-naming)
+        left   // NOLINT(readability-identifier-naming)
     };
 
     static constexpr fp SQRT2_2 = 0.707106781186547524400844362104849039284835937688474036588L;
@@ -88,8 +88,9 @@ namespace dd {
 
     // calculates the Units in Last Place (ULP) distance of two floating point numbers
     [[maybe_unused]] static std::size_t ulpDistance(fp a, fp b) {
-        if (a == b)
+        if (a == b) {
             return 0;
+        }
 
         std::size_t ulps   = 1;
         fp          nextFP = std::nextafter(a, b);

--- a/include/dd/DensityNoiseTable.hpp
+++ b/include/dd/DensityNoiseTable.hpp
@@ -35,15 +35,15 @@ namespace dd {
         // access functions
         [[nodiscard]] const auto& getTable() const { return table; }
 
-        static std::size_t hash(const OperandType& a, const std::vector<signed char>& usedQubits) {
+        static std::size_t hash(const OperandType& a, const std::vector<Qubit>& usedQubits) {
             std::size_t i = 0;
-            for (auto qubit: usedQubits) {
+            for (const auto qubit: usedQubits) {
                 i = (i << 3U) + i * qubit + qubit;
             }
             return (std::hash<OperandType>{}(a) + i) & MASK;
         }
 
-        void insert(const OperandType& operand, const ResultType& result, const std::vector<signed char>& usedQubits) {
+        void insert(const OperandType& operand, const ResultType& result, const std::vector<Qubit>& usedQubits) {
             const auto key   = hash(operand, usedQubits);
             auto&      entry = table[key];
             entry.result     = result;
@@ -52,22 +52,29 @@ namespace dd {
             ++count;
         }
 
-        ResultType lookup(const OperandType& operand, const std::vector<signed char>& usedQubits) {
+        ResultType lookup(const OperandType& operand, const std::vector<Qubit>& usedQubits) {
             ResultType result{};
             lookups++;
             const auto key   = hash(operand, usedQubits);
             auto&      entry = table[key];
-            if (entry.result.p == nullptr) return result;
-            if (entry.operand != operand) return result;
-            if (entry.usedQubits != usedQubits) return result;
+            if (entry.result.p == nullptr) {
+                return result;
+            }
+            if (entry.operand != operand) {
+                return result;
+            }
+            if (entry.usedQubits != usedQubits) {
+                return result;
+            }
             hits++;
             return entry.result;
         }
 
         void clear() {
             if (count > 0) {
-                for (auto& entry: table)
+                for (auto& entry: table) {
                     entry.result.p = nullptr;
+                }
                 count = 0;
             }
         }

--- a/include/dd/DensityNoiseTable.hpp
+++ b/include/dd/DensityNoiseTable.hpp
@@ -80,7 +80,8 @@ namespace dd {
         }
 
         [[nodiscard]] fp hitRatio() const { return static_cast<fp>(hits) / lookups; }
-        std::ostream&    printStatistics(std::ostream& os = std::cout) {
+
+        std::ostream& printStatistics(std::ostream& os = std::cout) {
             os << "hits: " << hits << ", looks: " << lookups << ", ratio: " << hitRatio() << std::endl;
             return os;
         }

--- a/include/dd/Edge.hpp
+++ b/include/dd/Edge.hpp
@@ -33,8 +33,8 @@ namespace dd {
         [[nodiscard]] constexpr bool isTerminal() const { return Node::isTerminal(p); }
 
         // edges pointing to zero and one terminals
-        static inline Edge one{Node::terminal, Complex::one};
-        static inline Edge zero{Node::terminal, Complex::zero};
+        static const inline Edge one{Node::terminal, Complex::one};
+        static const inline Edge zero{Node::terminal, Complex::zero};
 
         [[nodiscard]] static constexpr Edge terminal(const Complex& w) { return {Node::terminal, w}; }
         [[nodiscard]] constexpr bool        isZeroTerminal() const { return Node::isTerminal(p) && w == Complex::zero; }
@@ -95,7 +95,7 @@ namespace std {
     template<class Node>
     struct hash<dd::Edge<Node>> {
         std::size_t operator()(dd::Edge<Node> const& e) const noexcept {
-            auto h1 = dd::murmur64(reinterpret_cast<std::size_t>(e.p));
+            auto h1 = dd::murmur64(reinterpret_cast<std::size_t>(e.p)); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
             auto h2 = std::hash<dd::Complex>{}(e.w);
             return dd::combineHash(h1, h2);
         }
@@ -104,7 +104,7 @@ namespace std {
     template<class Node>
     struct hash<dd::CachedEdge<Node>> {
         std::size_t operator()(dd::CachedEdge<Node> const& e) const noexcept {
-            auto h1 = dd::murmur64(reinterpret_cast<std::size_t>(e.p));
+            auto h1 = dd::murmur64(reinterpret_cast<std::size_t>(e.p)); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
             auto h2 = std::hash<dd::ComplexValue>{}(e.w);
             return dd::combineHash(h1, h2);
         }

--- a/include/dd/Edge.hpp
+++ b/include/dd/Edge.hpp
@@ -33,7 +33,7 @@ namespace dd {
         [[nodiscard]] constexpr bool isTerminal() const { return Node::isTerminal(p); }
 
         // edges pointing to zero and one terminals
-        static const inline Edge one{Node::terminal, Complex::one}; // NOLINT(readability-identifier-naming) automatic renaming does not work reliably, so skip linting
+        static const inline Edge one{Node::terminal, Complex::one};   // NOLINT(readability-identifier-naming) automatic renaming does not work reliably, so skip linting
         static const inline Edge zero{Node::terminal, Complex::zero}; // NOLINT(readability-identifier-naming) automatic renaming does not work reliably, so skip linting
 
         [[nodiscard]] static constexpr Edge terminal(const Complex& w) { return {Node::terminal, w}; }

--- a/include/dd/Edge.hpp
+++ b/include/dd/Edge.hpp
@@ -33,8 +33,8 @@ namespace dd {
         [[nodiscard]] constexpr bool isTerminal() const { return Node::isTerminal(p); }
 
         // edges pointing to zero and one terminals
-        static const inline Edge one{Node::terminal, Complex::one};
-        static const inline Edge zero{Node::terminal, Complex::zero};
+        static const inline Edge one{Node::terminal, Complex::one}; // NOLINT(readability-identifier-naming) automatic renaming does not work reliably, so skip linting
+        static const inline Edge zero{Node::terminal, Complex::zero}; // NOLINT(readability-identifier-naming) automatic renaming does not work reliably, so skip linting
 
         [[nodiscard]] static constexpr Edge terminal(const Complex& w) { return {Node::terminal, w}; }
         [[nodiscard]] constexpr bool        isZeroTerminal() const { return Node::isTerminal(p) && w == Complex::zero; }
@@ -95,7 +95,7 @@ namespace std {
     template<class Node>
     struct hash<dd::Edge<Node>> {
         std::size_t operator()(dd::Edge<Node> const& e) const noexcept {
-            auto h1 = dd::murmur64(reinterpret_cast<std::size_t>(e.p)); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+            auto h1 = dd::murmur64(reinterpret_cast<std::size_t>(e.p));
             auto h2 = std::hash<dd::Complex>{}(e.w);
             return dd::combineHash(h1, h2);
         }
@@ -104,7 +104,7 @@ namespace std {
     template<class Node>
     struct hash<dd::CachedEdge<Node>> {
         std::size_t operator()(dd::CachedEdge<Node> const& e) const noexcept {
-            auto h1 = dd::murmur64(reinterpret_cast<std::size_t>(e.p)); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+            auto h1 = dd::murmur64(reinterpret_cast<std::size_t>(e.p));
             auto h2 = std::hash<dd::ComplexValue>{}(e.w);
             return dd::combineHash(h1, h2);
         }

--- a/include/dd/Export.hpp
+++ b/include/dd/Export.hpp
@@ -126,11 +126,14 @@ namespace dd {
         if (std::abs(mag - 1) < ComplexTable<>::tolerance()) {
             if (std::abs(phase) < ComplexTable<>::tolerance()) {
                 return "1";
-            } else if (std::abs(phase - dd::PI_2) < ComplexTable<>::tolerance()) {
+            }
+            if (std::abs(phase - dd::PI_2) < ComplexTable<>::tolerance()) {
                 return "i";
-            } else if (std::abs(phase + dd::PI_2) < ComplexTable<>::tolerance()) {
+            }
+            if (std::abs(phase + dd::PI_2) < ComplexTable<>::tolerance()) {
                 return "-i";
-            } else if (std::abs(std::abs(phase) - dd::PI) < ComplexTable<>::tolerance()) {
+            }
+            if (std::abs(std::abs(phase) - dd::PI) < ComplexTable<>::tolerance()) {
                 return "-1";
             }
             printPhaseFormatted(ss, phase);
@@ -141,7 +144,8 @@ namespace dd {
             ss << "-";
             dd::ComplexValue::printFormatted(ss, mag);
             return ss.str();
-        } else if (std::abs(phase) < ComplexTable<>::tolerance()) {
+        }
+        if (std::abs(phase) < ComplexTable<>::tolerance()) {
             dd::ComplexValue::printFormatted(ss, mag);
             return ss.str();
         }
@@ -337,13 +341,13 @@ namespace dd {
     }
     template<class Edge>
     static std::ostream& memoryNode(const Edge& e, std::ostream& os) {
-        constexpr std::size_t N         = std::tuple_size_v<decltype(e.p->e)>;
+        constexpr std::size_t n         = std::tuple_size_v<decltype(e.p->e)>;
         auto                  nodelabel = (reinterpret_cast<std::uintptr_t>(e.p) & 0x001fffffU) >> 1U; // this allows for 2^20 (roughly 1e6) unique nodes
         os << nodelabel << "[label=<";
         os << R"(<font point-size="10"><table border="1" cellspacing="0" cellpadding="2" style="rounded">)";
-        os << R"(<tr><td colspan=")" << N << R"(" border="1" sides="B">)" << std::hex << reinterpret_cast<std::uintptr_t>(e.p) << std::dec << " ref: " << e.p->ref << "</td></tr>";
+        os << R"(<tr><td colspan=")" << n << R"(" border="1" sides="B">)" << std::hex << reinterpret_cast<std::uintptr_t>(e.p) << std::dec << " ref: " << e.p->ref << "</td></tr>";
         os << "<tr>";
-        for (std::size_t i = 0; i < N; ++i) {
+        for (std::size_t i = 0; i < n; ++i) {
             os << "<td port=\"" << i << R"(" href="javascript:;" border="0" tooltip=")" << e.p->e[i].w.toString(false, 4) << "\">";
             if (e.p->e[i] == Edge::zero) {
                 os << "&nbsp;0 "
@@ -359,25 +363,27 @@ namespace dd {
         return os;
     }
 
-    [[maybe_unused]] static std::ostream& bwEdge(const mEdge& from, const mEdge& to, short idx, std::ostream& os, bool edgeLabels = false, bool classic = false, bool formatAsPolar = true) {
+    [[maybe_unused]] static std::ostream& bwEdge(const mEdge& from, const mEdge& to, std::uint_fast8_t idx, std::ostream& os, bool edgeLabels = false, bool classic = false, bool formatAsPolar = true) {
         auto fromlabel = (reinterpret_cast<std::uintptr_t>(from.p) & 0x001fffffU) >> 1U;
         auto tolabel   = (reinterpret_cast<std::uintptr_t>(to.p) & 0x001fffffU) >> 1U;
 
         os << fromlabel << ":" << idx << ":";
         if (classic) {
-            if (idx == 0)
+            if (idx == 0) {
                 os << "sw";
-            else if (idx == 1 || idx == 2)
+            } else if (idx == 1 || idx == 2) {
                 os << "s";
-            else
+            } else {
                 os << "se";
+            }
         } else {
-            if (idx == 0)
+            if (idx == 0) {
                 os << "sw";
-            else if (idx == 1)
+            } else if (idx == 1) {
                 os << "se";
-            else
+            } else {
                 os << 's';
+            }
         }
         os << "->";
         if (to.isTerminal()) {
@@ -398,7 +404,7 @@ namespace dd {
 
         return os;
     }
-    [[maybe_unused]] static std::ostream& bwEdge(const vEdge& from, const vEdge& to, short idx, std::ostream& os, bool edgeLabels = false, [[maybe_unused]] bool classic = false, bool formatAsPolar = true) {
+    [[maybe_unused]] static std::ostream& bwEdge(const vEdge& from, const vEdge& to, std::uint_fast8_t idx, std::ostream& os, bool edgeLabels = false, [[maybe_unused]] bool classic = false, bool formatAsPolar = true) {
         auto fromlabel = (reinterpret_cast<std::uintptr_t>(from.p) & 0x001fffffU) >> 1U;
         auto tolabel   = (reinterpret_cast<std::uintptr_t>(to.p) & 0x001fffffU) >> 1U;
 
@@ -422,25 +428,27 @@ namespace dd {
 
         return os;
     }
-    [[maybe_unused]] static std::ostream& coloredEdge(const mEdge& from, const mEdge& to, short idx, std::ostream& os, bool edgeLabels = false, bool classic = false, bool formatAsPolar = true) {
+    [[maybe_unused]] static std::ostream& coloredEdge(const mEdge& from, const mEdge& to, std::uint_fast8_t idx, std::ostream& os, bool edgeLabels = false, bool classic = false, bool formatAsPolar = true) {
         auto fromlabel = (reinterpret_cast<std::uintptr_t>(from.p) & 0x001fffffU) >> 1U;
         auto tolabel   = (reinterpret_cast<std::uintptr_t>(to.p) & 0x001fffffU) >> 1U;
 
         os << fromlabel << ":" << idx << ":";
         if (classic) {
-            if (idx == 0)
+            if (idx == 0) {
                 os << "sw";
-            else if (idx == 1 || idx == 2)
+            } else if (idx == 1 || idx == 2) {
                 os << "s";
-            else
+            } else {
                 os << "se";
+            }
         } else {
-            if (idx == 0)
+            if (idx == 0) {
                 os << "sw";
-            else if (idx == 1)
+            } else if (idx == 1) {
                 os << "se";
-            else
+            } else {
                 os << 's';
+            }
         }
         os << "->";
         if (to.isTerminal()) {
@@ -459,7 +467,7 @@ namespace dd {
 
         return os;
     }
-    [[maybe_unused]] static std::ostream& coloredEdge(const vEdge& from, const vEdge& to, short idx, std::ostream& os, bool edgeLabels = false, [[maybe_unused]] bool classic = false, bool formatAsPolar = true) {
+    [[maybe_unused]] static std::ostream& coloredEdge(const vEdge& from, const vEdge& to, std::uint_fast8_t idx, std::ostream& os, bool edgeLabels = false, [[maybe_unused]] bool classic = false, bool formatAsPolar = true) {
         auto fromlabel = (reinterpret_cast<std::uintptr_t>(from.p) & 0x001fffffU) >> 1U;
         auto tolabel   = (reinterpret_cast<std::uintptr_t>(to.p) & 0x001fffffU) >> 1U;
 
@@ -482,7 +490,7 @@ namespace dd {
         return os;
     }
     template<class Edge>
-    static std::ostream& memoryEdge(const Edge& from, const Edge& to, short idx, std::ostream& os, bool edgeLabels = false) {
+    static std::ostream& memoryEdge(const Edge& from, const Edge& to, std::uint_fast8_t idx, std::ostream& os, bool edgeLabels = false) {
         auto fromlabel = (reinterpret_cast<std::uintptr_t>(from.p) & 0x001fffffU) >> 1U;
         auto tolabel   = (reinterpret_cast<std::uintptr_t>(to.p) & 0x001fffffU) >> 1U;
 
@@ -554,12 +562,15 @@ namespace dd {
             q.pop();
 
             // base case
-            if (node->isTerminal())
+            if (node->isTerminal()) {
                 continue;
+            }
 
             // check if node has already been processed
             auto ret = nodes.emplace(node->p);
-            if (!ret.second) continue;
+            if (!ret.second) {
+                continue;
+            }
 
             // node definition as HTML-like label (href="javascript:;" is used as workaround to make tooltips work)
             if (memory) {
@@ -622,27 +633,33 @@ namespace dd {
             os << SERIALIZATION_VERSION << "\n";
             os << basic.w.toString(false, 16) << "\n";
         }
-        std::int_least64_t                             next_index = 0;
-        std::unordered_map<vNode*, std::int_least64_t> node_index{};
+        std::int_least64_t                             nextIndex = 0;
+        std::unordered_map<vNode*, std::int_least64_t> nodeIndex{};
 
         // POST ORDER TRAVERSAL USING ONE STACK   https://www.geeksforgeeks.org/iterative-postorder-traversal-using-stack/
         std::stack<const vEdge*> stack{};
 
-        auto node = &basic;
+        const auto* node = &basic;
         if (!node->isTerminal()) {
             do {
                 while (node != nullptr && !node->isTerminal()) {
-                    for (short i = RADIX - 1; i > 0; --i) {
+                    for (auto i = RADIX - 1; i > 0; --i) {
                         auto& edge = node->p->e[i];
-                        if (edge.isTerminal()) continue;
-                        if (edge.w.approximatelyZero()) continue;
-                        if (node_index.find(edge.p) != node_index.end()) continue;
+                        if (edge.isTerminal()) {
+                            continue;
+                        }
+                        if (edge.w.approximatelyZero()) {
+                            continue;
+                        }
+                        if (nodeIndex.find(edge.p) != nodeIndex.end()) {
+                            continue;
+                        }
 
                         // non-zero edge to be included
                         stack.push(&edge);
                     }
                     stack.push(node);
-                    node = &node->p->e[0];
+                    node = &node->p->e[0]; // NOLINT(readability-container-data-pointer)
                 }
                 node = stack.top();
                 stack.pop();
@@ -650,46 +667,51 @@ namespace dd {
                 bool hasChild = false;
                 for (auto i = 1U; i < RADIX && !hasChild; ++i) {
                     auto& edge = node->p->e[i];
-                    if (edge.w.approximatelyZero()) continue;
-                    if (node_index.find(edge.p) != node_index.end()) continue;
-                    if (!stack.empty())
+                    if (edge.w.approximatelyZero()) {
+                        continue;
+                    }
+                    if (nodeIndex.find(edge.p) != nodeIndex.end()) {
+                        continue;
+                    }
+                    if (!stack.empty()) {
                         hasChild = edge.p == stack.top()->p;
+                    }
                 }
 
                 if (hasChild) {
-                    const auto temp = stack.top();
+                    const auto* const temp = stack.top();
                     stack.pop();
                     stack.push(node);
                     node = temp;
                 } else {
-                    if (node_index.find(node->p) != node_index.end()) {
+                    if (nodeIndex.find(node->p) != nodeIndex.end()) {
                         node = nullptr;
                         continue;
                     }
-                    node_index[node->p] = next_index;
-                    next_index++;
+                    nodeIndex[node->p] = nextIndex;
+                    nextIndex++;
 
                     if (writeBinary) {
-                        os.write(reinterpret_cast<const char*>(&node_index[node->p]), sizeof(decltype(node_index[node->p])));
+                        os.write(reinterpret_cast<const char*>(&nodeIndex[node->p]), sizeof(decltype(nodeIndex[node->p])));
                         os.write(reinterpret_cast<const char*>(&node->p->v), sizeof(decltype(node->p->v)));
 
                         // iterate over edges in reverse to guarantee correct processing order
                         for (auto i = 0U; i < RADIX; ++i) {
-                            auto&              edge     = node->p->e[i];
-                            std::int_least64_t edge_idx = edge.isTerminal() ? -1 : node_index[edge.p];
-                            os.write(reinterpret_cast<const char*>(&edge_idx), sizeof(decltype(edge_idx)));
+                            auto&              edge    = node->p->e[i];
+                            std::int_least64_t edgeIdx = edge.isTerminal() ? -1 : nodeIndex[edge.p];
+                            os.write(reinterpret_cast<const char*>(&edgeIdx), sizeof(decltype(edgeIdx)));
                             edge.w.writeBinary(os);
                         }
                     } else {
-                        os << node_index[node->p] << " " << static_cast<std::size_t>(node->p->v);
+                        os << nodeIndex[node->p] << " " << static_cast<std::size_t>(node->p->v);
 
                         // iterate over edges in reverse to guarantee correct processing order
                         for (auto i = 0U; i < RADIX; ++i) {
                             os << " (";
                             auto& edge = node->p->e[i];
                             if (!edge.w.approximatelyZero()) {
-                                std::int_least64_t edge_idx = edge.isTerminal() ? -1 : node_index[edge.p];
-                                os << edge_idx << " " << edge.w.toString(false, 16);
+                                std::int_least64_t edgeIdx = edge.isTerminal() ? -1 : nodeIndex[edge.p];
+                                os << edgeIdx << " " << edge.w.toString(false, 16);
                             }
                             os << ")";
                         }
@@ -700,38 +722,39 @@ namespace dd {
             } while (!stack.empty());
         }
     }
-    static void serializeMatrix(const mEdge& basic, std::int_least64_t& idx, std::unordered_map<mNode*, std::int_least64_t>& node_index, std::unordered_set<mNode*>& visited, std::ostream& os, bool writeBinary = false) {
+
+    static void serializeMatrix(const mEdge& basic, std::int_least64_t& idx, std::unordered_map<mNode*, std::int_least64_t>& nodeIndex, std::unordered_set<mNode*>& visited, std::ostream& os, bool writeBinary = false) {
         if (!basic.isTerminal()) {
             for (auto& e: basic.p->e) {
                 if (auto [iter, success] = visited.insert(e.p); success) {
-                    serializeMatrix(e, idx, node_index, visited, os, writeBinary);
+                    serializeMatrix(e, idx, nodeIndex, visited, os, writeBinary);
                 }
             }
 
-            if (node_index.find(basic.p) == node_index.end()) {
-                node_index[basic.p] = idx;
+            if (nodeIndex.find(basic.p) == nodeIndex.end()) {
+                nodeIndex[basic.p] = idx;
                 ++idx;
             }
 
             if (writeBinary) {
-                os.write(reinterpret_cast<const char*>(&node_index[basic.p]), sizeof(decltype(node_index[basic.p])));
+                os.write(reinterpret_cast<const char*>(&nodeIndex[basic.p]), sizeof(decltype(nodeIndex[basic.p])));
                 os.write(reinterpret_cast<const char*>(&basic.p->v), sizeof(decltype(basic.p->v)));
 
                 // iterate over edges in reverse to guarantee correct processing order
                 for (auto& edge: basic.p->e) {
-                    std::int_least64_t edge_idx = edge.isTerminal() ? -1 : node_index[edge.p];
-                    os.write(reinterpret_cast<const char*>(&edge_idx), sizeof(decltype(edge_idx)));
+                    std::int_least64_t edgeIdx = edge.isTerminal() ? -1 : nodeIndex[edge.p];
+                    os.write(reinterpret_cast<const char*>(&edgeIdx), sizeof(decltype(edgeIdx)));
                     edge.w.writeBinary(os);
                 }
             } else {
-                os << node_index[basic.p] << " " << static_cast<std::size_t>(basic.p->v);
+                os << nodeIndex[basic.p] << " " << static_cast<std::size_t>(basic.p->v);
 
                 // iterate over edges in reverse to guarantee correct processing order
                 for (auto& edge: basic.p->e) {
                     os << " (";
                     if (!edge.w.approximatelyZero()) {
-                        std::int_least64_t edge_idx = edge.isTerminal() ? -1 : node_index[edge.p];
-                        os << edge_idx << " " << edge.w.toString(false, 16);
+                        std::int_least64_t edgeIdx = edge.isTerminal() ? -1 : nodeIndex[edge.p];
+                        os << edgeIdx << " " << edge.w.toString(false, 16);
                     }
                     os << ")";
                 }
@@ -748,9 +771,9 @@ namespace dd {
             os << basic.w.toString(false, std::numeric_limits<dd::fp>::max_digits10) << "\n";
         }
         std::int_least64_t                             idx = 0;
-        std::unordered_map<mNode*, std::int_least64_t> node_index{};
+        std::unordered_map<mNode*, std::int_least64_t> nodeIndex{};
         std::unordered_set<mNode*>                     visited{};
-        serializeMatrix(basic, idx, node_index, visited, os, writeBinary);
+        serializeMatrix(basic, idx, nodeIndex, visited, os, writeBinary);
     }
     template<class Edge>
     static void serialize(const Edge& basic, const std::string& outputFilename, bool writeBinary = false) {
@@ -765,7 +788,7 @@ namespace dd {
 
     template<typename Edge>
     static void exportEdgeWeights(const Edge& edge, std::ostream& stream) {
-        struct priocmp {
+        struct Priocmp {
             bool operator()(const Edge* left, const Edge* right) {
                 return left->p->v < right->p->v;
             }
@@ -774,7 +797,7 @@ namespace dd {
 
         std::unordered_set<decltype(edge.p)> nodes{};
 
-        std::priority_queue<const Edge*, std::vector<const Edge*>, priocmp> q;
+        std::priority_queue<const Edge*, std::vector<const Edge*>, Priocmp> q;
         q.push(&edge);
 
         // bfs until finished
@@ -783,12 +806,15 @@ namespace dd {
             q.pop();
 
             // base case
-            if (edgePtr->isTerminal())
+            if (edgePtr->isTerminal()) {
                 continue;
+            }
 
             // check if edgePtr has already been processed
             auto ret = nodes.emplace(edgePtr->p);
-            if (!ret.second) continue;
+            if (!ret.second) {
+                continue;
+            }
 
             // iterate over edges in reverse to guarantee correct proceossing order
             for (auto i = static_cast<Qubit>(edgePtr->p->e.size() - 1); i >= 0; --i) {

--- a/include/dd/GateMatrixDefinitions.hpp
+++ b/include/dd/GateMatrixDefinitions.hpp
@@ -14,6 +14,7 @@
 
 namespace dd {
     // Complex constants
+    // NOLINTBEGIN(readability-identifier-naming) As these constants are used by other projects, we keep the naming
     constexpr ComplexValue complex_one       = {1., 0.};
     constexpr ComplexValue complex_mone      = {-1., 0.};
     constexpr ComplexValue complex_zero      = {0., 0.};
@@ -82,5 +83,6 @@ namespace dd {
                            complex_zero,
                            {std::cos(lambda / 2.), std::sin(lambda / 2.)}}};
     }
+    // NOLINTEND(readability-identifier-naming)
 } // namespace dd
 #endif //DD_PACKAGE_GATEMATRIXDEFINITIONS_H

--- a/include/dd/Node.hpp
+++ b/include/dd/Node.hpp
@@ -206,6 +206,7 @@ namespace dd {
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     inline dNode dNode::terminalNode{{{{nullptr, Complex::zero}, {nullptr, Complex::zero}, {nullptr, Complex::zero}, {nullptr, Complex::zero}}}, nullptr, 0, -1, 0};
 
+    // NOLINTNEXTLINE(clang-diagnostic-unused-function) It's used but clang-tidy in our CI complains...
     static inline dEdge densityFromMatrixEdge(const mEdge& e) {
         return dEdge{reinterpret_cast<dNode*>(e.p), e.w};
     }

--- a/include/dd/Node.hpp
+++ b/include/dd/Node.hpp
@@ -53,7 +53,8 @@ namespace dd {
 
         [[nodiscard]] inline bool isIdentity() const { return (flags & 16U) != 0; }
         [[nodiscard]] inline bool isSymmetric() const { return (flags & 32U) != 0; }
-        inline void               setIdentity(bool identity) {
+
+        inline void setIdentity(bool identity) {
             if (identity) {
                 flags = (flags | 16);
             } else {

--- a/include/dd/Node.hpp
+++ b/include/dd/Node.hpp
@@ -15,21 +15,21 @@
 #include <utility>
 
 namespace dd {
-    struct vNode {
+    struct vNode {// NOLINT(readability-identifier-naming)
         std::array<Edge<vNode>, RADIX> e{};    // edges out of this node
         vNode*                         next{}; // used to link nodes in unique table
         RefCount                       ref{};  // reference count
         Qubit                          v{};    // variable index (nonterminal) value (-1 for terminal)
 
-        static vNode            terminalNode;
-        constexpr static vNode* terminal{&terminalNode};
+        static vNode            terminalNode; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+        constexpr static vNode* terminal{&terminalNode};// NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
         static constexpr bool isTerminal(const vNode* p) { return p == terminal; }
     };
     using vEdge       = Edge<vNode>;
     using vCachedEdge = CachedEdge<vNode>;
 
-    inline vNode vNode::terminalNode{{{{nullptr, Complex::zero}, {nullptr, Complex::zero}}}, nullptr, 0U, -1};
+    inline vNode vNode::terminalNode{{{{nullptr, Complex::zero}, {nullptr, Complex::zero}}}, nullptr, 0U, -1}; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
     struct mNode {
         std::array<Edge<mNode>, NEDGE> e{};    // edges out of this node
@@ -44,29 +44,32 @@ namespace dd {
         // 2 = mark first path edge (tmp flag),
         // 1 = mark path is conjugated (tmp flag))
 
-        static mNode            terminalNode;
-        constexpr static mNode* terminal{&terminalNode};
+        static mNode            terminalNode;// NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+        constexpr static mNode* terminal{&terminalNode};// NOLINT(cppcoreguidelines-avoid-non-const-global-variables,readability-identifier-naming)
 
         static constexpr bool isTerminal(const mNode* p) { return p == terminal; }
 
-        [[nodiscard]] inline bool isIdentity() const { return flags & 16; }
-        [[nodiscard]] inline bool isSymmetric() const { return flags & 32; }
+        [[nodiscard]] inline bool isIdentity() const { return (flags & 16U) != 0; }
+        [[nodiscard]] inline bool isSymmetric() const { return (flags & 32U) != 0; }
         inline void               setIdentity(bool identity) {
-            if (identity)
+            if (identity) {
                 flags = (flags | 16);
-            else
+            } else {
                 flags = (flags & (~16));
+}
         }
         inline void setSymmetric(bool symmetric) {
-            if (symmetric)
+            if (symmetric) {
                 flags = (flags | 32);
-            else
+            } else {
                 flags = (flags & (~32));
+}
         }
     };
     using mEdge       = Edge<mNode>;
     using mCachedEdge = CachedEdge<mNode>;
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     inline mNode mNode::terminalNode{{{{nullptr, Complex::zero}, {nullptr, Complex::zero}, {nullptr, Complex::zero}, {nullptr, Complex::zero}}}, nullptr, 0U, -1, 32 + 16};
 
     struct dNode {
@@ -82,16 +85,16 @@ namespace dd {
         // 2 = mark first path edge (tmp flag),
         // 1 = mark path is conjugated (tmp flag))
 
-        static dNode            terminalNode;
-        constexpr static dNode* terminal{&terminalNode};
+        static dNode            terminalNode; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+        constexpr static dNode* terminal{&terminalNode}; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
         static constexpr bool   isTerminal(const dNode* p) { return p == terminal; }
 
         [[nodiscard]] [[maybe_unused]] static inline bool tempDensityMatrixFlagsEqual(const std::uint_least8_t a, const std::uint_least8_t b) { return getDensityMatrixTempFlags(a) == getDensityMatrixTempFlags(b); }
 
-        [[nodiscard]] static inline bool isConjugateTempFlagSet(const std::uintptr_t p) { return p & (1ULL << 0); }
-        [[nodiscard]] static inline bool isNonReduceTempFlagSet(const std::uintptr_t p) { return p & (1ULL << 1); }
-        [[nodiscard]] static inline bool isDensityMatrixTempFlagSet(const std::uintptr_t p) { return p & (1ULL << 2); }
-        [[nodiscard]] static inline bool isDensityMatrixNode(const std::uintptr_t p) { return p & (1ULL << 3); }
+        [[nodiscard]] static inline bool isConjugateTempFlagSet(const std::uintptr_t p) { return (p & (1ULL << 0)) != 0U; }
+        [[nodiscard]] static inline bool isNonReduceTempFlagSet(const std::uintptr_t p) { return (p & (1ULL << 1)) != 0U; }
+        [[nodiscard]] static inline bool isDensityMatrixTempFlagSet(const std::uintptr_t p) { return (p & (1ULL << 2)) != 0U; }
+        [[nodiscard]] static inline bool isDensityMatrixNode(const std::uintptr_t p) { return (p & (1ULL << 3)) != 0U; }
 
         [[nodiscard]] [[maybe_unused]] static inline bool isConjugateTempFlagSet(const dNode* p) { return isConjugateTempFlagSet(reinterpret_cast<std::uintptr_t>(p)); }
         [[nodiscard]] [[maybe_unused]] static inline bool isNonReduceTempFlagSet(const dNode* p) { return isNonReduceTempFlagSet(reinterpret_cast<std::uintptr_t>(p)); }
@@ -109,10 +112,11 @@ namespace dd {
         void unsetTempDensityMatrixFlags() { flags = flags & (~7U); }
 
         inline void setDensityMatrixNodeFlag(bool densityMatrix) {
-            if (densityMatrix)
+            if (densityMatrix) {
                 flags = (flags | 8);
-            else
+            } else {
                 flags = (flags & (~8));
+}
         }
 
         static inline std::uint_least8_t alignDensityNodeNode(dNode*& p) {
@@ -126,7 +130,8 @@ namespace dd {
             if (isNonReduceTempFlagSet(flags) && !isConjugateTempFlagSet(flags)) {
                 // first edge paths are not modified and the property is inherited by all child paths
                 return flags;
-            } else if (!isConjugateTempFlagSet(flags)) {
+            }
+            if (!isConjugateTempFlagSet(flags)) {
                 // Conjugate the second edge (i.e. negate the complex part of the second edge)
                 p->e[2].w.i = dd::CTEntry::flipPointerSign(p->e[2].w.i);
                 setConjugateTempFlagTrue(p->e[2].p);
@@ -194,6 +199,7 @@ namespace dd {
     };
     using dEdge       = Edge<dNode>;
     using dCachedEdge = CachedEdge<dNode>;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     inline dNode dNode::terminalNode{{{{nullptr, Complex::zero}, {nullptr, Complex::zero}, {nullptr, Complex::zero}, {nullptr, Complex::zero}}}, nullptr, 0, -1, 0};
 
     static inline dEdge densityFromMatrixEdge(const mEdge& e) {

--- a/include/dd/Node.hpp
+++ b/include/dd/Node.hpp
@@ -33,7 +33,8 @@ namespace dd {
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     inline vNode vNode::terminalNode{{{{nullptr, Complex::zero}, {nullptr, Complex::zero}}}, nullptr, 0U, -1};
 
-    struct mNode {                             // NOLINT(readability-identifier-naming)
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    struct mNode {
         std::array<Edge<mNode>, NEDGE> e{};    // edges out of this node
         mNode*                         next{}; // used to link nodes in unique table
         RefCount                       ref{};  // reference count

--- a/include/dd/Node.hpp
+++ b/include/dd/Node.hpp
@@ -15,23 +15,25 @@
 #include <utility>
 
 namespace dd {
-    struct vNode {// NOLINT(readability-identifier-naming)
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    struct vNode {
         std::array<Edge<vNode>, RADIX> e{};    // edges out of this node
         vNode*                         next{}; // used to link nodes in unique table
         RefCount                       ref{};  // reference count
         Qubit                          v{};    // variable index (nonterminal) value (-1 for terminal)
 
-        static vNode            terminalNode; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-        constexpr static vNode* terminal{&terminalNode};// NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+        static vNode            terminalNode;            // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+        constexpr static vNode* terminal{&terminalNode}; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables,readability-identifier-naming)
 
         static constexpr bool isTerminal(const vNode* p) { return p == terminal; }
     };
     using vEdge       = Edge<vNode>;
     using vCachedEdge = CachedEdge<vNode>;
 
-    inline vNode vNode::terminalNode{{{{nullptr, Complex::zero}, {nullptr, Complex::zero}}}, nullptr, 0U, -1}; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+    inline vNode vNode::terminalNode{{{{nullptr, Complex::zero}, {nullptr, Complex::zero}}}, nullptr, 0U, -1};
 
-    struct mNode {
+    struct mNode {                             // NOLINT(readability-identifier-naming)
         std::array<Edge<mNode>, NEDGE> e{};    // edges out of this node
         mNode*                         next{}; // used to link nodes in unique table
         RefCount                       ref{};  // reference count
@@ -44,8 +46,8 @@ namespace dd {
         // 2 = mark first path edge (tmp flag),
         // 1 = mark path is conjugated (tmp flag))
 
-        static mNode            terminalNode;// NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-        constexpr static mNode* terminal{&terminalNode};// NOLINT(cppcoreguidelines-avoid-non-const-global-variables,readability-identifier-naming)
+        static mNode            terminalNode;            // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+        constexpr static mNode* terminal{&terminalNode}; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables,readability-identifier-naming)
 
         static constexpr bool isTerminal(const mNode* p) { return p == terminal; }
 
@@ -56,14 +58,14 @@ namespace dd {
                 flags = (flags | 16);
             } else {
                 flags = (flags & (~16));
-}
+            }
         }
         inline void setSymmetric(bool symmetric) {
             if (symmetric) {
                 flags = (flags | 32);
             } else {
                 flags = (flags & (~32));
-}
+            }
         }
     };
     using mEdge       = Edge<mNode>;
@@ -72,6 +74,7 @@ namespace dd {
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     inline mNode mNode::terminalNode{{{{nullptr, Complex::zero}, {nullptr, Complex::zero}, {nullptr, Complex::zero}, {nullptr, Complex::zero}}}, nullptr, 0U, -1, 32 + 16};
 
+    // NOLINTNEXTLINE(readability-identifier-naming)
     struct dNode {
         std::array<Edge<dNode>, NEDGE> e{};    // edges out of this node
         dNode*                         next{}; // used to link nodes in unique table
@@ -85,8 +88,8 @@ namespace dd {
         // 2 = mark first path edge (tmp flag),
         // 1 = mark path is conjugated (tmp flag))
 
-        static dNode            terminalNode; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-        constexpr static dNode* terminal{&terminalNode}; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+        static dNode            terminalNode;            // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+        constexpr static dNode* terminal{&terminalNode}; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables,readability-identifier-naming)
         static constexpr bool   isTerminal(const dNode* p) { return p == terminal; }
 
         [[nodiscard]] [[maybe_unused]] static inline bool tempDensityMatrixFlagsEqual(const std::uint_least8_t a, const std::uint_least8_t b) { return getDensityMatrixTempFlags(a) == getDensityMatrixTempFlags(b); }
@@ -116,7 +119,7 @@ namespace dd {
                 flags = (flags | 8);
             } else {
                 flags = (flags & (~8));
-}
+            }
         }
 
         static inline std::uint_least8_t alignDensityNodeNode(dNode*& p) {

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -2644,7 +2644,7 @@ namespace dd {
                     if (!std::regex_match(line, m, complexWeightRegex)) {
                         throw std::runtime_error("Regex did not match second line: " + line);
                     }
-                    rootweight.from_string(m.str(1), m.str(2));
+                    rootweight.fromString(m.str(1), m.str(2));
                 }
 
                 while (std::getline(is, line)) {
@@ -2674,7 +2674,7 @@ namespace dd {
                         }
 
                         edgeIndices[i] = std::stoi(m.str(edgeIdx + 1));
-                        edgeWeights[i].from_string(m.str(edgeIdx + 3), m.str(edgeIdx + 4));
+                        edgeWeights[i].fromString(m.str(edgeIdx + 3), m.str(edgeIdx + 4));
                     }
 
                     result = deserializeNode(nodeIndex, v, edgeIndices, edgeWeights, nodes);

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -1380,7 +1380,7 @@ namespace dd {
                             } else if (!m.w.exactlyZero()) {
                                 dEdge::applyDmChangesToEdges(edge[idx], m);
                                 auto oldE = edge[idx];
-                                edge[idx]  = add2(edge[idx], m);
+                                edge[idx] = add2(edge[idx], m);
                                 dEdge::revertDmChangesToEdges(edge[idx], e2);
                                 cn.returnToCache(oldE.w);
                                 cn.returnToCache(m.w);
@@ -1394,7 +1394,7 @@ namespace dd {
                                 edge[idx] = m;
                             } else if (!m.w.exactlyZero()) {
                                 auto oldE = edge[idx];
-                                edge[idx]  = add2(edge[idx], m);
+                                edge[idx] = add2(edge[idx], m);
                                 cn.returnToCache(oldE.w);
                                 cn.returnToCache(m.w);
                             }
@@ -2565,9 +2565,9 @@ namespace dd {
                             }
                             edges[i].w = cn.lookup(currentEdge->p->e[i].w);
                         }
-                        root                        = makeDDNode(currentEdge->p->v, edges);
+                        root                       = makeDDNode(currentEdge->p->v, edges);
                         mappedNode[currentEdge->p] = root.p;
-                        currentEdge                 = nullptr;
+                        currentEdge                = nullptr;
                     }
                 } while (!stack.empty());
 
@@ -2627,7 +2627,7 @@ namespace dd {
 
                 const std::string complexRealRegex = R"(([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?(?![ \d\.]*(?:[eE][+-])?\d*[iI]))?)";
                 const std::string complexImagRegex = R"(( ?[+-]? ?(?:(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)?[iI])?)";
-                const std::string edgeRegex         = " \\(((-?\\d+) (" + complexRealRegex + complexImagRegex + "))?\\)";
+                const std::string edgeRegex        = " \\(((-?\\d+) (" + complexRealRegex + complexImagRegex + "))?\\)";
                 const std::regex  complexWeightRegex(complexRealRegex + complexImagRegex);
 
                 std::string lineConstruct = "(\\d+) (\\d+)";
@@ -2635,8 +2635,8 @@ namespace dd {
                     lineConstruct += "(?:" + edgeRegex + ")";
                 }
                 lineConstruct += " *(?:#.*)?";
-                const std::regex  lineRegex(lineConstruct);
-                std::smatch m;
+                const std::regex lineRegex(lineConstruct);
+                std::smatch      m;
 
                 std::string line;
                 if (std::getline(is, line)) {
@@ -2665,7 +2665,7 @@ namespace dd {
                     // match 6: real
                     // match 7: imag (without i)
                     nodeIndex = std::stoi(m.str(1));
-                    v          = static_cast<Qubit>(std::stoi(m.str(2)));
+                    v         = static_cast<Qubit>(std::stoi(m.str(2)));
 
                     for (auto edgeIdx = 3U, i = 0U; i < N; i++, edgeIdx += 5) {
                         if (m.str(edgeIdx).empty()) {
@@ -2784,8 +2784,8 @@ namespace dd {
     private:
         template<class Edge>
         bool isLocallyConsistent2(const Edge& e) {
-            const auto *ptrR = CTEntry::getAlignedPointer(e.w.r);
-            const auto *ptrI = CTEntry::getAlignedPointer(e.w.i);
+            const auto* ptrR = CTEntry::getAlignedPointer(e.w.r);
+            const auto* ptrI = CTEntry::getAlignedPointer(e.w.i);
 
             if ((ptrR->refCount == 0 || ptrI->refCount == 0) && e.w != Complex::one && e.w != Complex::zero) {
                 std::clog << "\nLOCAL INCONSISTENCY FOUND\nOffending Number: " << e.w << " (" << ptrR->refCount << ", " << ptrI->refCount << ")\n\n";

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -2843,8 +2843,8 @@ namespace dd {
 
         template<class Edge>
         void checkConsistencyCounter(const Edge& edge, const std::map<ComplexTable<>::Entry*, std::size_t>& weightMap, const std::map<decltype(edge.p), std::size_t>& nodeMap) {
-            const auto* rPtr = CTEntry::getAlignedPointer(edge.w.r);
-            const auto* iPtr = CTEntry::getAlignedPointer(edge.w.i);
+            auto* rPtr = CTEntry::getAlignedPointer(edge.w.r);
+            auto* iPtr = CTEntry::getAlignedPointer(edge.w.i);
 
             if (weightMap.at(rPtr) > rPtr->refCount && rPtr != Complex::one.r && rPtr != Complex::zero.i && rPtr != &ComplexTable<>::sqrt2_2) {
                 std::clog << "\nOffending weight: " << edge.w << "\n";

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -2514,7 +2514,7 @@ namespace dd {
                 constexpr std::size_t n = std::tuple_size_v<decltype(original.p->e)>;
                 do {
                     while (currentEdge != nullptr && !currentEdge->isTerminal()) {
-                        for (short i = n - 1; i > 0; --i) { // NOLINT(google-runtime-int)
+                        for (std::size_t i = n - 1; i > 0; --i) {
                             auto& edge = currentEdge->p->e[i];
                             if (edge.isTerminal()) {
                                 continue;

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -2334,7 +2334,7 @@ namespace dd {
             return mat;
         }
 
-        void getDensityMatrix(dEdge& e, Complex& amp, std::size_t i, std::size_t j, CMat& mat) {
+        void getDensityMatrix(dEdge& e, const Complex& amp, std::size_t i, std::size_t j, CMat& mat) {
             // calculate new accumulated amplitude
             auto c = cn.mulCached(e.w, amp);
 

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -434,6 +434,7 @@ namespace dd {
             std::array<mEdge, NEDGE> em{};
             auto                     it = controls.begin();
             for (auto i = 0U; i < NEDGE; ++i) {
+                // NOLINTNEXTLINE(clang-diagnostic-float-equal) it has to be really zero
                 if (mat[i].r == 0 && mat[i].i == 0) {
                     em[i] = mEdge::zero;
                 } else {

--- a/include/dd/StochasticNoiseOperationTable.hpp
+++ b/include/dd/StochasticNoiseOperationTable.hpp
@@ -6,7 +6,10 @@
 #ifndef DDpackage_NOISEOPERATIONTABLE_HPP
 #define DDpackage_NOISEOPERATIONTABLE_HPP
 
+#include "Definitions.hpp"
+
 #include <array>
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <iostream>

--- a/include/dd/StochasticNoiseOperationTable.hpp
+++ b/include/dd/StochasticNoiseOperationTable.hpp
@@ -41,7 +41,9 @@ namespace dd {
             lookups++;
             Edge r{};
             auto entry = table.at(target).at(kind);
-            if (entry.p == nullptr) return r;
+            if (entry.p == nullptr) {
+                return r;
+            }
             hits++;
             return entry;
         }

--- a/include/dd/StochasticNoiseOperationTable.hpp
+++ b/include/dd/StochasticNoiseOperationTable.hpp
@@ -61,7 +61,7 @@ namespace dd {
 
         [[nodiscard]] fp hitRatio() const { return static_cast<fp>(hits) / lookups; }
 
-        std::ostream&    printStatistics(std::ostream& os = std::cout) {
+        std::ostream& printStatistics(std::ostream& os = std::cout) {
             os << "hits: " << hits << ", looks: " << lookups << ", ratio: " << hitRatio() << std::endl;
             return os;
         }

--- a/include/dd/StochasticNoiseOperationTable.hpp
+++ b/include/dd/StochasticNoiseOperationTable.hpp
@@ -60,6 +60,7 @@ namespace dd {
         }
 
         [[nodiscard]] fp hitRatio() const { return static_cast<fp>(hits) / lookups; }
+
         std::ostream&    printStatistics(std::ostream& os = std::cout) {
             os << "hits: " << hits << ", looks: " << lookups << ", ratio: " << hitRatio() << std::endl;
             return os;

--- a/include/dd/ToffoliTable.hpp
+++ b/include/dd/ToffoliTable.hpp
@@ -84,7 +84,8 @@ namespace dd {
         }
 
         [[nodiscard]] fp hitRatio() const { return static_cast<fp>(hits) / lookups; }
-        std::ostream&    printStatistics(std::ostream& os = std::cout) {
+
+        std::ostream& printStatistics(std::ostream& os = std::cout) {
             os << "hits: " << hits << ", looks: " << lookups << ", ratio: " << hitRatio() << std::endl;
             return os;
         }

--- a/include/dd/ToffoliTable.hpp
+++ b/include/dd/ToffoliTable.hpp
@@ -44,21 +44,29 @@ namespace dd {
             Edge        r{};
             const auto  key   = hash(controls, target);
             const auto& entry = table[key];
-            if (entry.e.p == nullptr) return r;
-            if (entry.n != n) return r;
-            if (entry.target != target) return r;
-            if (entry.controls != controls) return r;
+            if (entry.e.p == nullptr) {
+                return r;
+            }
+            if (entry.n != n) {
+                return r;
+            }
+            if (entry.target != target) {
+                return r;
+            }
+            if (entry.controls != controls) {
+                return r;
+            }
             hits++;
             return entry.e;
         }
 
         static std::size_t hash(const Controls& controls, Qubit target) {
-            auto key = static_cast<std::size_t>(std::make_unsigned<Qubit>::type(target));
+            auto key = static_cast<std::size_t>(static_cast<std::make_unsigned<Qubit>::type>(target));
             for (const auto& control: controls) {
                 if (control.type == dd::Control::Type::pos) {
-                    key *= 29u * control.qubit;
+                    key *= 29UL * control.qubit;
                 } else {
-                    key *= 71u * control.qubit;
+                    key *= 71UL * control.qubit;
                 }
             }
             return key & MASK;
@@ -66,8 +74,9 @@ namespace dd {
 
         void clear() {
             if (count > 0) {
-                for (auto& entry: table)
+                for (auto& entry: table) {
                     entry.e.p = nullptr;
+                }
                 count = 0;
             }
             hits    = 0;

--- a/include/dd/UnaryComputeTable.hpp
+++ b/include/dd/UnaryComputeTable.hpp
@@ -49,8 +49,12 @@ namespace dd {
             lookups++;
             const auto key   = hash(operand);
             auto&      entry = table[key];
-            if (entry.result.p == nullptr) return result;
-            if (entry.operand != operand) return result;
+            if (entry.result.p == nullptr) {
+                return result;
+            }
+            if (entry.operand != operand) {
+                return result;
+            }
 
             hits++;
             return entry.result;
@@ -58,8 +62,9 @@ namespace dd {
 
         void clear() {
             if (count > 0) {
-                for (auto& entry: table)
+                for (auto& entry: table) {
                     entry.result.p = nullptr;
+                }
                 count = 0;
             }
             hits    = 0;

--- a/include/dd/UnaryComputeTable.hpp
+++ b/include/dd/UnaryComputeTable.hpp
@@ -72,7 +72,8 @@ namespace dd {
         }
 
         [[nodiscard]] fp hitRatio() const { return static_cast<fp>(hits) / lookups; }
-        std::ostream&    printStatistics(std::ostream& os = std::cout) {
+
+        std::ostream& printStatistics(std::ostream& os = std::cout) {
             os << "hits: " << hits << ", looks: " << lookups << ", ratio: " << hitRatio() << std::endl;
             return os;
         }

--- a/include/dd/UniqueTable.hpp
+++ b/include/dd/UniqueTable.hpp
@@ -34,13 +34,7 @@ namespace dd {
     class UniqueTable {
     public:
         explicit UniqueTable(std::size_t nvars):
-            nvars(nvars), chunkID(0), allocationSize(INITIAL_ALLOCATION_SIZE), gcLimit(INITIAL_GC_LIMIT) {
-            // allocate first chunk of nodes
-            chunks.emplace_back(allocationSize);
-            allocations += allocationSize;
-            allocationSize *= GROWTH_FACTOR;
-            chunkIt    = chunks[0].begin();
-            chunkEndIt = chunks[0].end();
+            nvars(nvars) {
         }
 
         ~UniqueTable() = default;
@@ -93,16 +87,18 @@ namespace dd {
         // NOTE: reference counting is to be adjusted by function invoking the table lookup and only normalized nodes shall be stored.
         Edge<Node> lookup(const Edge<Node>& e, bool keepNode = false) {
             // there are unique terminal nodes
-            if (e.isTerminal())
+            if (e.isTerminal()) {
                 return e;
+            }
 
             lookups++;
             const auto key = hash(e.p);
             const auto v   = e.p->v;
 
             // successors of a node shall either have successive variable numbers or be terminals
-            for ([[maybe_unused]] const auto& edge: e.p->e)
+            for ([[maybe_unused]] const auto& edge: e.p->e) {
                 assert(edge.p->v == v - 1 || edge.isTerminal());
+            }
 
             Node* p = tables[v][key];
             while (p != nullptr) {
@@ -118,8 +114,9 @@ namespace dd {
                     assert(p->v == e.p->v);
 
                     // successors of a node shall either have successive variable numbers or be terminals
-                    for ([[maybe_unused]] const auto& edge: e.p->e)
+                    for ([[maybe_unused]] const auto& edge: e.p->e) {
                         assert(edge.p->v == v - 1 || edge.isTerminal());
+                    }
 
                     return {p, e.w};
                 }
@@ -171,8 +168,9 @@ namespace dd {
         // each child if this is the first reference
         void incRef(const Edge<Node>& e) {
             dd::ComplexNumbers::incRef(e.w);
-            if (e.p == nullptr || e.isTerminal())
+            if (e.p == nullptr || e.isTerminal()) {
                 return;
+            }
 
             if (e.p->ref == std::numeric_limits<decltype(e.p->ref)>::max()) {
                 std::clog << "[WARN] MAXREFCNT reached for p=" << reinterpret_cast<std::uintptr_t>(e.p)
@@ -199,8 +197,12 @@ namespace dd {
         // each child if this is the last reference
         void decRef(const Edge<Node>& e) {
             dd::ComplexNumbers::decRef(e.w);
-            if (e.p == nullptr || e.isTerminal()) return;
-            if (e.p->ref == std::numeric_limits<decltype(e.p->ref)>::max()) return;
+            if (e.p == nullptr || e.isTerminal()) {
+                return;
+            }
+            if (e.p->ref == std::numeric_limits<decltype(e.p->ref)>::max()) {
+                return;
+            }
 
             if (e.p->ref == 0) {
                 throw std::runtime_error("In decref: ref==0 before decref\n");
@@ -223,8 +225,9 @@ namespace dd {
 
         std::size_t garbageCollect(bool force = false) {
             gcCalls++;
-            if ((!force && nodeCount < gcLimit) || nodeCount == 0)
+            if ((!force && nodeCount < gcLimit) || nodeCount == 0) {
                 return 0;
+            }
 
             gcRuns++;
             std::size_t collected = 0;
@@ -317,8 +320,9 @@ namespace dd {
                           << "\n";
                 for (std::size_t key = 0; key < table.size(); ++key) {
                     auto p = table[key];
-                    if (p != nullptr)
+                    if (p != nullptr) {
                         std::cout << "\tkey=" << key << ": ";
+                    }
 
                     while (p != nullptr) {
                         std::cout << "\t\t" << std::hex << reinterpret_cast<std::uintptr_t>(p) << std::dec << " "
@@ -338,8 +342,9 @@ namespace dd {
 
         void printActive() {
             std::cout << "#printActive: " << activeNodeCount << ", ";
-            for (const auto& a: active)
+            for (const auto& a: active) {
                 std::cout << a << " ";
+            }
             std::cout << "\n";
         }
 
@@ -369,13 +374,13 @@ namespace dd {
         std::vector<Table> tables{nvars};
 
         Node*                                available{};
-        std::vector<std::vector<Node>>       chunks{};
-        std::size_t                          chunkID;
-        typename std::vector<Node>::iterator chunkIt;
-        typename std::vector<Node>::iterator chunkEndIt;
-        std::size_t                          allocationSize;
+        std::vector<std::vector<Node>>       chunks{1, std::vector<Node>{allocationSize}};
+        std::size_t                          chunkID{0};
+        typename std::vector<Node>::iterator chunkIt{chunks[0].begin()};
+        typename std::vector<Node>::iterator chunkEndIt{chunks[0].end()};
+        std::size_t                          allocationSize{INITIAL_ALLOCATION_SIZE * GROWTH_FACTOR};
 
-        std::size_t allocations   = 0;
+        std::size_t allocations   = INITIAL_ALLOCATION_SIZE;
         std::size_t nodeCount     = 0;
         std::size_t peakNodeCount = 0;
 
@@ -393,7 +398,7 @@ namespace dd {
         // garbage collection
         std::size_t gcCalls = 0;
         std::size_t gcRuns  = 0;
-        std::size_t gcLimit = 250000;
+        std::size_t gcLimit = INITIAL_GC_LIMIT;
     };
 
 } // namespace dd

--- a/include/dd/UniqueTable.hpp
+++ b/include/dd/UniqueTable.hpp
@@ -374,7 +374,7 @@ namespace dd {
         std::vector<Table> tables{nvars};
 
         Node*                                available{};
-        std::vector<std::vector<Node>>       chunks{1, std::vector<Node>{allocationSize}};
+        std::vector<std::vector<Node>>       chunks{1, std::vector<Node>{INITIAL_ALLOCATION_SIZE}};
         std::size_t                          chunkID{0};
         typename std::vector<Node>::iterator chunkIt{chunks[0].begin()};
         typename std::vector<Node>::iterator chunkEndIt{chunks[0].end()};

--- a/include/dd/UniqueTable.hpp
+++ b/include/dd/UniqueTable.hpp
@@ -8,7 +8,7 @@
 
 #include "ComplexNumbers.hpp"
 #include "Definitions.hpp"
-#include "Edge.hpp"
+#include "Node.hpp"
 
 #include <algorithm>
 #include <array>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,7 @@ endif ()
 add_executable(${PROJECT_NAME}_example ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
 target_link_libraries(${PROJECT_NAME}_example PRIVATE ${PROJECT_NAME})
 set_target_properties(${PROJECT_NAME}_example PROPERTIES FOLDER tests CMAKE_CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF)
+target_compile_features(${PROJECT_NAME}_example PUBLIC cxx_std_17)
 enable_lto(${PROJECT_NAME}_example)
 
 macro(package_add_test TESTNAME)
@@ -40,6 +41,7 @@ macro(package_add_test TESTNAME)
 	# discover tests
 	gtest_discover_tests(${TESTNAME} WORKING_DIRECTORY ${PROJECT_DIR} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_DIR}")
 	set_target_properties(${TESTNAME} PROPERTIES FOLDER tests CMAKE_CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF)
+	target_compile_features(${TESTNAME} PUBLIC cxx_std_17)
 	enable_lto(${TESTNAME})
 endmacro()
 
@@ -60,6 +62,7 @@ add_executable(${PROJECT_NAME}_bench EXCLUDE_FROM_ALL ${CMAKE_CURRENT_SOURCE_DIR
 # link the Google benchmark infrastructure and a default main fuction to the benchmark executable.
 target_link_libraries(${PROJECT_NAME}_bench PRIVATE ${PROJECT_NAME} benchmark::benchmark_main Threads::Threads)
 set_target_properties(${PROJECT_NAME}_bench PROPERTIES FOLDER tests CMAKE_CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF)
+target_compile_features(${PROJECT_NAME}_bench PUBLIC cxx_std_17)
 enable_lto(${PROJECT_NAME}_bench)
 
 add_custom_command(TARGET ${PROJECT_NAME}_bench

--- a/test/bench_package.cpp
+++ b/test/bench_package.cpp
@@ -115,8 +115,8 @@ BENCHMARK(BM_MakeSingleQubitGateDD_TargetBottom)->Apply(qubitRange); // NOLINT
 
 static void BM_MakeControlledQubitGateDD_ControlBottom_TargetTop(benchmark::State& state) {
     dd::QubitCount nqubits = state.range(0);
-    auto dd      = std::make_unique<dd::Package<>>(nqubits);
-    for ([[maybe_unused]]  auto _: state) {
+    auto           dd      = std::make_unique<dd::Package<>>(nqubits);
+    for ([[maybe_unused]] auto _: state) {
         benchmark::DoNotOptimize(dd->makeGateDD(dd::Xmat, nqubits, 0_pc, static_cast<dd::Qubit>(nqubits - 1)));
     }
 }
@@ -124,8 +124,8 @@ BENCHMARK(BM_MakeControlledQubitGateDD_ControlBottom_TargetTop)->Apply(qubitRang
 
 static void BM_MakeControlledQubitGateDD_ControlBottom_TargetMiddle(benchmark::State& state) {
     dd::QubitCount nqubits = state.range(0);
-    auto dd      = std::make_unique<dd::Package<>>(nqubits);
-    for ([[maybe_unused]]  auto _: state) {
+    auto           dd      = std::make_unique<dd::Package<>>(nqubits);
+    for ([[maybe_unused]] auto _: state) {
         benchmark::DoNotOptimize(dd->makeGateDD(dd::Xmat, nqubits, 0_pc, static_cast<dd::Qubit>(nqubits / 2)));
     }
 }
@@ -133,8 +133,8 @@ BENCHMARK(BM_MakeControlledQubitGateDD_ControlBottom_TargetMiddle)->Apply(qubitR
 
 static void BM_MakeControlledQubitGateDD_ControlTop_TargetMiddle(benchmark::State& state) {
     dd::QubitCount nqubits = state.range(0);
-    auto dd      = std::make_unique<dd::Package<>>(nqubits);
-    for ([[maybe_unused]]  auto _: state) {
+    auto           dd      = std::make_unique<dd::Package<>>(nqubits);
+    for ([[maybe_unused]] auto _: state) {
         benchmark::DoNotOptimize(dd->makeGateDD(dd::Xmat, nqubits, dd::Control{static_cast<dd::Qubit>(nqubits - 1)}, static_cast<dd::Qubit>(nqubits / 2)));
     }
 }
@@ -142,8 +142,8 @@ BENCHMARK(BM_MakeControlledQubitGateDD_ControlTop_TargetMiddle)->Apply(qubitRang
 
 static void BM_MakeControlledQubitGateDD_ControlTop_TargetBottom(benchmark::State& state) {
     dd::QubitCount nqubits = state.range(0);
-    auto dd      = std::make_unique<dd::Package<>>(nqubits);
-    for ([[maybe_unused]]  auto _: state) {
+    auto           dd      = std::make_unique<dd::Package<>>(nqubits);
+    for ([[maybe_unused]] auto _: state) {
         benchmark::DoNotOptimize(dd->makeGateDD(dd::Xmat, nqubits, dd::Control{static_cast<dd::Qubit>(nqubits - 1)}, 0));
     }
 }
@@ -155,8 +155,8 @@ static void BM_MakeFullControlledToffoliDD_TargetTop(benchmark::State& state) {
     dd::Controls   controls;
     for (std::size_t i = 0; i < static_cast<std::size_t>(nqubits - 1); i++) {
         controls.insert({static_cast<dd::Qubit>(i)});
-}
-    for ([[maybe_unused]]  auto _: state) {
+    }
+    for ([[maybe_unused]] auto _: state) {
         benchmark::DoNotOptimize(dd->makeGateDD(dd::Xmat, nqubits, controls, static_cast<dd::Qubit>(nqubits - 1)));
     }
 }
@@ -169,9 +169,9 @@ static void BM_MakeFullControlledToffoliDD_TargetMiddle(benchmark::State& state)
     for (std::size_t i = 0; i < nqubits; i++) {
         if (i != nqubits / 2) {
             controls.insert({static_cast<dd::Qubit>(i)});
-}
-}
-    for ([[maybe_unused]]  auto _: state) {
+        }
+    }
+    for ([[maybe_unused]] auto _: state) {
         benchmark::DoNotOptimize(dd->makeGateDD(dd::Xmat, nqubits, controls, static_cast<dd::Qubit>(nqubits / 2)));
     }
 }
@@ -183,8 +183,8 @@ static void BM_MakeFullControlledToffoliDD_TargetBottom(benchmark::State& state)
     dd::Controls   controls;
     for (std::size_t i = 1; i < nqubits; i++) {
         controls.insert({static_cast<dd::Qubit>(i)});
-}
-    for ([[maybe_unused]]  auto _: state) {
+    }
+    for ([[maybe_unused]] auto _: state) {
         benchmark::DoNotOptimize(dd->makeGateDD(dd::Xmat, nqubits, controls, 0));
     }
 }
@@ -192,9 +192,9 @@ BENCHMARK(BM_MakeFullControlledToffoliDD_TargetBottom)->Apply(qubitRange); // NO
 
 static void BM_MakeSWAPDD(benchmark::State& state) {
     dd::QubitCount nqubits = state.range(0);
-    auto dd      = std::make_unique<dd::Package<>>(nqubits);
+    auto           dd      = std::make_unique<dd::Package<>>(nqubits);
 
-    for ([[maybe_unused]]  auto _: state) {
+    for ([[maybe_unused]] auto _: state) {
         auto sv = dd->makeGateDD(dd::Xmat, nqubits, dd::Control{static_cast<dd::Qubit>(nqubits - 1)}, 0);
         sv      = dd->multiply(sv, dd->multiply(dd->makeGateDD(dd::Xmat, nqubits, 0_pc, static_cast<dd::Qubit>(nqubits - 1)), sv));
 
@@ -210,11 +210,11 @@ BENCHMARK(BM_MakeSWAPDD)->Apply(qubitRange); // NOLINT
 
 static void bmMxVX(benchmark::State& state) {
     dd::QubitCount nqubits = state.range(0);
-    auto dd      = std::make_unique<dd::Package<>>(nqubits);
-    auto zero    = dd->makeZeroState(nqubits);
-    auto x       = dd->makeGateDD(dd::Xmat, nqubits, 0);
+    auto           dd      = std::make_unique<dd::Package<>>(nqubits);
+    auto           zero    = dd->makeZeroState(nqubits);
+    auto           x       = dd->makeGateDD(dd::Xmat, nqubits, 0);
 
-    for ([[maybe_unused]]  auto _: state) {
+    for ([[maybe_unused]] auto _: state) {
         auto sim = dd->multiply(x, zero);
         benchmark::DoNotOptimize(sim);
         // clear compute table so the next iteration does not find the result cached
@@ -225,11 +225,11 @@ BENCHMARK(bmMxVX)->Apply(qubitRange); // NOLINT
 
 static void bmMxVH(benchmark::State& state) {
     dd::QubitCount nqubits = state.range(0);
-    auto dd      = std::make_unique<dd::Package<>>(nqubits);
-    auto zero    = dd->makeZeroState(nqubits);
-    auto h       = dd->makeGateDD(dd::Hmat, nqubits, 0);
+    auto           dd      = std::make_unique<dd::Package<>>(nqubits);
+    auto           zero    = dd->makeZeroState(nqubits);
+    auto           h       = dd->makeGateDD(dd::Hmat, nqubits, 0);
 
-    for ([[maybe_unused]]  auto _: state) {
+    for ([[maybe_unused]] auto _: state) {
         auto sim = dd->multiply(h, zero);
         benchmark::DoNotOptimize(sim);
         // clear compute table so the next iteration does not find the result cached
@@ -240,11 +240,11 @@ BENCHMARK(bmMxVH)->Apply(qubitRange); // NOLINT
 
 static void bmMxVT(benchmark::State& state) {
     dd::QubitCount nqubits = state.range(0);
-    auto dd      = std::make_unique<dd::Package<>>(nqubits);
-    auto zero    = dd->makeZeroState(nqubits);
-    auto t       = dd->makeGateDD(dd::Tmat, nqubits, 0);
+    auto           dd      = std::make_unique<dd::Package<>>(nqubits);
+    auto           zero    = dd->makeZeroState(nqubits);
+    auto           t       = dd->makeGateDD(dd::Tmat, nqubits, 0);
 
-    for ([[maybe_unused]]  auto _: state) {
+    for ([[maybe_unused]] auto _: state) {
         auto sim = dd->multiply(t, zero);
         benchmark::DoNotOptimize(sim);
         // clear compute table so the next iteration does not find the result cached
@@ -261,7 +261,7 @@ static void bmMxVCxControlTopTargetBottom(benchmark::State& state) {
     auto plus                  = dd->makeBasisState(nqubits, basisStates);
     auto cx                    = dd->makeGateDD(dd::Xmat, nqubits, dd::Control{static_cast<dd::Qubit>(nqubits - 1)}, 0);
 
-    for ([[maybe_unused]]  auto _: state) {
+    for ([[maybe_unused]] auto _: state) {
         auto sim = dd->multiply(cx, plus);
         benchmark::DoNotOptimize(sim);
         // clear compute table so the next iteration does not find the result cached
@@ -278,7 +278,7 @@ static void bmMxVCxControlBottomTargetTop(benchmark::State& state) {
     auto plus                  = dd->makeBasisState(nqubits, basisStates);
     auto cx                    = dd->makeGateDD(dd::Xmat, nqubits, 0_pc, static_cast<dd::Qubit>(nqubits - 1));
 
-    for ([[maybe_unused]]  auto _: state) {
+    for ([[maybe_unused]] auto _: state) {
         auto sim = dd->multiply(cx, plus);
         benchmark::DoNotOptimize(sim);
         // clear compute table so the next iteration does not find the result cached
@@ -289,10 +289,10 @@ BENCHMARK(bmMxVCxControlBottomTargetTop)->Apply(qubitRange); // NOLINT
 
 static void bmMxVHadamardLayer(benchmark::State& state) {
     dd::QubitCount nqubits = state.range(0);
-    auto dd      = std::make_unique<dd::Package<>>(nqubits);
-    auto zero    = dd->makeZeroState(nqubits);
+    auto           dd      = std::make_unique<dd::Package<>>(nqubits);
+    auto           zero    = dd->makeZeroState(nqubits);
 
-    for ([[maybe_unused]]  auto _: state) {
+    for ([[maybe_unused]] auto _: state) {
         auto sv = zero;
         for (int i = 0; i < nqubits; ++i) {
             auto h = dd->makeGateDD(dd::Hmat, nqubits, static_cast<dd::Qubit>(i));
@@ -306,11 +306,11 @@ BENCHMARK(bmMxVHadamardLayer)->Apply(qubitRange); // NOLINT
 
 static void bmMxVGhz(benchmark::State& state) {
     dd::QubitCount nqubits = state.range(0);
-    auto dd      = std::make_unique<dd::Package<>>(nqubits);
-    auto zero    = dd->makeZeroState(nqubits);
-    auto h       = dd->makeGateDD(dd::Hmat, nqubits, static_cast<dd::Qubit>(nqubits - 1));
+    auto           dd      = std::make_unique<dd::Package<>>(nqubits);
+    auto           zero    = dd->makeZeroState(nqubits);
+    auto           h       = dd->makeGateDD(dd::Hmat, nqubits, static_cast<dd::Qubit>(nqubits - 1));
 
-    for ([[maybe_unused]]  auto _: state) {
+    for ([[maybe_unused]] auto _: state) {
         auto sv = zero;
         sv      = dd->multiply(h, sv);
         for (auto i = static_cast<int>(nqubits - 2); i >= 0; --i) {
@@ -325,11 +325,11 @@ BENCHMARK(bmMxVGhz)->Apply(qubitRange); // NOLINT
 
 static void bmMxMBell(benchmark::State& state) {
     dd::QubitCount nqubits = state.range(0);
-    auto dd      = std::make_unique<dd::Package<>>(nqubits);
-    auto h       = dd->makeGateDD(dd::Hmat, nqubits, static_cast<dd::Qubit>(nqubits - 1));
-    auto cx      = dd->makeGateDD(dd::Xmat, nqubits, dd::Control{static_cast<dd::Qubit>(nqubits - 1)}, 0);
+    auto           dd      = std::make_unique<dd::Package<>>(nqubits);
+    auto           h       = dd->makeGateDD(dd::Hmat, nqubits, static_cast<dd::Qubit>(nqubits - 1));
+    auto           cx      = dd->makeGateDD(dd::Xmat, nqubits, dd::Control{static_cast<dd::Qubit>(nqubits - 1)}, 0);
 
-    for ([[maybe_unused]]  auto _: state) {
+    for ([[maybe_unused]] auto _: state) {
         auto bell = dd->multiply(cx, h);
         benchmark::DoNotOptimize(bell);
         // clear compute table so the next iteration does not find the result cached
@@ -340,9 +340,9 @@ BENCHMARK(bmMxMBell)->Apply(qubitRange); // NOLINT
 
 static void bmMxMGhz(benchmark::State& state) {
     dd::QubitCount nqubits = state.range(0);
-    auto dd      = std::make_unique<dd::Package<>>(nqubits);
+    auto           dd      = std::make_unique<dd::Package<>>(nqubits);
 
-    for ([[maybe_unused]]  auto _: state) {
+    for ([[maybe_unused]] auto _: state) {
         auto func = dd->makeGateDD(dd::Hmat, nqubits, static_cast<dd::Qubit>(nqubits - 1));
         for (auto i = static_cast<int>(nqubits - 2); i >= 0; --i) {
             auto cx = dd->makeGateDD(dd::Xmat, nqubits, dd::Control{static_cast<dd::Qubit>(nqubits - 1)}, static_cast<dd::Qubit>(i));
@@ -356,10 +356,10 @@ BENCHMARK(bmMxMGhz)->Apply(qubitRange); // NOLINT
 
 static void bmVUniqueTableGet(benchmark::State& state) {
     auto allocs = state.range(0);
-    for ([[maybe_unused]]  auto _: state) {
+    for ([[maybe_unused]] auto _: state) {
         auto dd = std::make_unique<dd::Package<>>(1);
         for (int i = 0; i < allocs; ++i) {
-            auto *p = dd->vUniqueTable.getNode();
+            auto* p = dd->vUniqueTable.getNode();
             benchmark::DoNotOptimize(p);
         }
     }
@@ -368,10 +368,10 @@ BENCHMARK(bmVUniqueTableGet)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)
 
 static void bmVUniqueTableGetAndReturn(benchmark::State& state) {
     auto allocs = state.range(0);
-    for ([[maybe_unused]]  auto _: state) {
+    for ([[maybe_unused]] auto _: state) {
         auto dd = std::make_unique<dd::Package<>>(1);
         for (int i = 0; i < allocs; ++i) {
-            auto *p = dd->vUniqueTable.getNode();
+            auto* p = dd->vUniqueTable.getNode();
             benchmark::DoNotOptimize(p);
             if (i % 5 == 0) {
                 dd->vUniqueTable.returnNode(p);
@@ -383,10 +383,10 @@ BENCHMARK(bmVUniqueTableGetAndReturn)->Unit(benchmark::kMillisecond)->RangeMulti
 
 static void bmMUniqueTableGet(benchmark::State& state) {
     auto allocs = state.range(0);
-    for ([[maybe_unused]]  auto _: state) {
+    for ([[maybe_unused]] auto _: state) {
         auto dd = std::make_unique<dd::Package<>>(1);
         for (int i = 0; i < allocs; ++i) {
-            auto *p = dd->mUniqueTable.getNode();
+            auto* p = dd->mUniqueTable.getNode();
             benchmark::DoNotOptimize(p);
             if (i % 5 == 0) {
                 dd->mUniqueTable.returnNode(p);
@@ -398,10 +398,10 @@ BENCHMARK(bmMUniqueTableGet)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)
 
 static void bmMUniqueTableGetAndReturn(benchmark::State& state) {
     auto allocs = state.range(0);
-    for ([[maybe_unused]]  auto _: state) {
+    for ([[maybe_unused]] auto _: state) {
         auto dd = std::make_unique<dd::Package<>>(1);
         for (int i = 0; i < allocs; ++i) {
-            auto *p = dd->mUniqueTable.getNode();
+            auto* p = dd->mUniqueTable.getNode();
             benchmark::DoNotOptimize(p);
             if (i % 5 == 0) {
                 dd->mUniqueTable.returnNode(p);

--- a/test/bench_package.cpp
+++ b/test/bench_package.cpp
@@ -11,7 +11,7 @@
 
 using namespace dd::literals;
 
-static void QubitRange(benchmark::internal::Benchmark* b) {
+static void qubitRange(benchmark::internal::Benchmark* b) {
     b->Unit(benchmark::kMicrosecond)->RangeMultiplier(2)->Range(2, 128);
 }
 
@@ -24,63 +24,63 @@ static void QubitRange(benchmark::internal::Benchmark* b) {
 ///
 
 static void BM_DDVectorNodeCreation(benchmark::State& state) {
-    for (auto _: state) {
+    for ([[maybe_unused]] auto _: state) {
         auto node = dd::vNode{};
         benchmark::DoNotOptimize(node);
         benchmark::ClobberMemory();
     }
 }
-BENCHMARK(BM_DDVectorNodeCreation)->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_DDVectorNodeCreation)->Unit(benchmark::kNanosecond); // NOLINT
 
 static void BM_DDMatrixNodeCreation(benchmark::State& state) {
-    for (auto _: state) {
+    for ([[maybe_unused]] auto _: state) {
         auto node = dd::mNode{};
         benchmark::DoNotOptimize(node);
         benchmark::ClobberMemory();
     }
 }
-BENCHMARK(BM_DDMatrixNodeCreation)->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_DDMatrixNodeCreation)->Unit(benchmark::kNanosecond); // NOLINT
 
-static void BM_ComplexNumbersCreation(benchmark::State& state) {
-    for (auto _: state) {
+static void bmComplexNumbersCreation(benchmark::State& state) {
+    for ([[maybe_unused]] auto _: state) {
         auto cn = dd::ComplexNumbers();
         benchmark::DoNotOptimize(cn);
         benchmark::ClobberMemory();
     }
 }
-BENCHMARK(BM_ComplexNumbersCreation)->Unit(benchmark::kMicrosecond);
+BENCHMARK(bmComplexNumbersCreation)->Unit(benchmark::kMicrosecond); // NOLINT
 
-static void BM_PackageCreation(benchmark::State& state) {
-    [[maybe_unused]] auto nqubits = state.range(0);
-    for (auto _: state) {
+static void bmPackageCreation(benchmark::State& state) {
+    dd::QubitCount nqubits = state.range(0);
+    for ([[maybe_unused]] auto _: state) {
         auto dd = std::make_unique<dd::Package<>>(nqubits);
         benchmark::DoNotOptimize(dd);
         benchmark::ClobberMemory();
     }
 }
-BENCHMARK(BM_PackageCreation)->Unit(benchmark::kMillisecond)->RangeMultiplier(2)->Range(2, 128);
+BENCHMARK(bmPackageCreation)->Unit(benchmark::kMillisecond)->RangeMultiplier(2)->Range(2, 128); // NOLINT
 
 ///
 /// Test creation of identity matrix
 ///
 
-static void BM_MakeIdentCached(benchmark::State& state) {
+static void bmMakeIdentCached(benchmark::State& state) {
     auto nqubits = state.range(0);
     auto dd      = std::make_unique<dd::Package<>>(nqubits);
-    for (auto _: state) {
+    for ([[maybe_unused]] auto _: state) {
         benchmark::DoNotOptimize(dd->makeIdent(nqubits));
     }
 }
-BENCHMARK(BM_MakeIdentCached)->Unit(benchmark::kNanosecond)->RangeMultiplier(2)->Range(2, 128);
+BENCHMARK(bmMakeIdentCached)->Unit(benchmark::kNanosecond)->RangeMultiplier(2)->Range(2, 128); // NOLINT
 
-static void BM_MakeIdent(benchmark::State& state) {
+static void bmMakeIdent(benchmark::State& state) {
     auto nqubits = state.range(0);
     auto dd      = std::make_unique<dd::Package<>>(nqubits);
-    for (auto _: state) {
+    for ([[maybe_unused]] auto _: state) {
         benchmark::DoNotOptimize(dd->makeGateDD(dd::Imat, nqubits, 0));
     }
 }
-BENCHMARK(BM_MakeIdent)->Apply(QubitRange);
+BENCHMARK(bmMakeIdent)->Apply(qubitRange); // NOLINT
 
 ///
 /// Test makeGateDD
@@ -89,108 +89,112 @@ BENCHMARK(BM_MakeIdent)->Apply(QubitRange);
 static void BM_MakeSingleQubitGateDD_TargetTop(benchmark::State& state) {
     auto nqubits = state.range(0);
     auto dd      = std::make_unique<dd::Package<>>(nqubits);
-    for (auto _: state) {
+    for ([[maybe_unused]] auto _: state) {
         benchmark::DoNotOptimize(dd->makeGateDD(dd::Xmat, nqubits, static_cast<dd::Qubit>(nqubits - 1)));
     }
 }
-BENCHMARK(BM_MakeSingleQubitGateDD_TargetTop)->Apply(QubitRange);
+BENCHMARK(BM_MakeSingleQubitGateDD_TargetTop)->Apply(qubitRange); // NOLINT
 
 static void BM_MakeSingleQubitGateDD_TargetMiddle(benchmark::State& state) {
     auto nqubits = state.range(0);
     auto dd      = std::make_unique<dd::Package<>>(nqubits);
-    for (auto _: state) {
+    for ([[maybe_unused]] auto _: state) {
         benchmark::DoNotOptimize(dd->makeGateDD(dd::Xmat, nqubits, static_cast<dd::Qubit>(nqubits / 2)));
     }
 }
-BENCHMARK(BM_MakeSingleQubitGateDD_TargetMiddle)->Apply(QubitRange);
+BENCHMARK(BM_MakeSingleQubitGateDD_TargetMiddle)->Apply(qubitRange); // NOLINT
 
 static void BM_MakeSingleQubitGateDD_TargetBottom(benchmark::State& state) {
     auto nqubits = state.range(0);
     auto dd      = std::make_unique<dd::Package<>>(nqubits);
-    for (auto _: state) {
+    for ([[maybe_unused]] auto _: state) {
         benchmark::DoNotOptimize(dd->makeGateDD(dd::Xmat, nqubits, 0));
     }
 }
-BENCHMARK(BM_MakeSingleQubitGateDD_TargetBottom)->Apply(QubitRange);
+BENCHMARK(BM_MakeSingleQubitGateDD_TargetBottom)->Apply(qubitRange); // NOLINT
 
 static void BM_MakeControlledQubitGateDD_ControlBottom_TargetTop(benchmark::State& state) {
-    auto nqubits = state.range(0);
+    dd::QubitCount nqubits = state.range(0);
     auto dd      = std::make_unique<dd::Package<>>(nqubits);
-    for (auto _: state) {
+    for ([[maybe_unused]]  auto _: state) {
         benchmark::DoNotOptimize(dd->makeGateDD(dd::Xmat, nqubits, 0_pc, static_cast<dd::Qubit>(nqubits - 1)));
     }
 }
-BENCHMARK(BM_MakeControlledQubitGateDD_ControlBottom_TargetTop)->Apply(QubitRange);
+BENCHMARK(BM_MakeControlledQubitGateDD_ControlBottom_TargetTop)->Apply(qubitRange); // NOLINT
 
 static void BM_MakeControlledQubitGateDD_ControlBottom_TargetMiddle(benchmark::State& state) {
-    auto nqubits = state.range(0);
+    dd::QubitCount nqubits = state.range(0);
     auto dd      = std::make_unique<dd::Package<>>(nqubits);
-    for (auto _: state) {
+    for ([[maybe_unused]]  auto _: state) {
         benchmark::DoNotOptimize(dd->makeGateDD(dd::Xmat, nqubits, 0_pc, static_cast<dd::Qubit>(nqubits / 2)));
     }
 }
-BENCHMARK(BM_MakeControlledQubitGateDD_ControlBottom_TargetMiddle)->Apply(QubitRange);
+BENCHMARK(BM_MakeControlledQubitGateDD_ControlBottom_TargetMiddle)->Apply(qubitRange); // NOLINT
 
 static void BM_MakeControlledQubitGateDD_ControlTop_TargetMiddle(benchmark::State& state) {
-    auto nqubits = state.range(0);
+    dd::QubitCount nqubits = state.range(0);
     auto dd      = std::make_unique<dd::Package<>>(nqubits);
-    for (auto _: state) {
+    for ([[maybe_unused]]  auto _: state) {
         benchmark::DoNotOptimize(dd->makeGateDD(dd::Xmat, nqubits, dd::Control{static_cast<dd::Qubit>(nqubits - 1)}, static_cast<dd::Qubit>(nqubits / 2)));
     }
 }
-BENCHMARK(BM_MakeControlledQubitGateDD_ControlTop_TargetMiddle)->Apply(QubitRange);
+BENCHMARK(BM_MakeControlledQubitGateDD_ControlTop_TargetMiddle)->Apply(qubitRange); // NOLINT
 
 static void BM_MakeControlledQubitGateDD_ControlTop_TargetBottom(benchmark::State& state) {
-    auto nqubits = state.range(0);
+    dd::QubitCount nqubits = state.range(0);
     auto dd      = std::make_unique<dd::Package<>>(nqubits);
-    for (auto _: state) {
+    for ([[maybe_unused]]  auto _: state) {
         benchmark::DoNotOptimize(dd->makeGateDD(dd::Xmat, nqubits, dd::Control{static_cast<dd::Qubit>(nqubits - 1)}, 0));
     }
 }
-BENCHMARK(BM_MakeControlledQubitGateDD_ControlTop_TargetBottom)->Apply(QubitRange);
+BENCHMARK(BM_MakeControlledQubitGateDD_ControlTop_TargetBottom)->Apply(qubitRange); // NOLINT
 
 static void BM_MakeFullControlledToffoliDD_TargetTop(benchmark::State& state) {
-    unsigned short nqubits = state.range(0);
+    dd::QubitCount nqubits = state.range(0);
     auto           dd      = std::make_unique<dd::Package<>>(nqubits);
     dd::Controls   controls;
-    for (std::size_t i = 0; i < static_cast<std::size_t>(nqubits - 1); i++)
+    for (std::size_t i = 0; i < static_cast<std::size_t>(nqubits - 1); i++) {
         controls.insert({static_cast<dd::Qubit>(i)});
-    for (auto _: state) {
+}
+    for ([[maybe_unused]]  auto _: state) {
         benchmark::DoNotOptimize(dd->makeGateDD(dd::Xmat, nqubits, controls, static_cast<dd::Qubit>(nqubits - 1)));
     }
 }
-BENCHMARK(BM_MakeFullControlledToffoliDD_TargetTop)->Apply(QubitRange);
+BENCHMARK(BM_MakeFullControlledToffoliDD_TargetTop)->Apply(qubitRange); // NOLINT
 
 static void BM_MakeFullControlledToffoliDD_TargetMiddle(benchmark::State& state) {
-    unsigned short nqubits = state.range(0);
+    dd::QubitCount nqubits = state.range(0);
     auto           dd      = std::make_unique<dd::Package<>>(nqubits);
     dd::Controls   controls;
-    for (std::size_t i = 0; i < nqubits; i++)
-        if (i != nqubits / 2)
+    for (std::size_t i = 0; i < nqubits; i++) {
+        if (i != nqubits / 2) {
             controls.insert({static_cast<dd::Qubit>(i)});
-    for (auto _: state) {
+}
+}
+    for ([[maybe_unused]]  auto _: state) {
         benchmark::DoNotOptimize(dd->makeGateDD(dd::Xmat, nqubits, controls, static_cast<dd::Qubit>(nqubits / 2)));
     }
 }
-BENCHMARK(BM_MakeFullControlledToffoliDD_TargetMiddle)->Apply(QubitRange);
+BENCHMARK(BM_MakeFullControlledToffoliDD_TargetMiddle)->Apply(qubitRange); // NOLINT
 
 static void BM_MakeFullControlledToffoliDD_TargetBottom(benchmark::State& state) {
-    unsigned short nqubits = state.range(0);
+    dd::QubitCount nqubits = state.range(0);
     auto           dd      = std::make_unique<dd::Package<>>(nqubits);
     dd::Controls   controls;
-    for (std::size_t i = 1; i < nqubits; i++)
+    for (std::size_t i = 1; i < nqubits; i++) {
         controls.insert({static_cast<dd::Qubit>(i)});
-    for (auto _: state) {
+}
+    for ([[maybe_unused]]  auto _: state) {
         benchmark::DoNotOptimize(dd->makeGateDD(dd::Xmat, nqubits, controls, 0));
     }
 }
-BENCHMARK(BM_MakeFullControlledToffoliDD_TargetBottom)->Apply(QubitRange);
+BENCHMARK(BM_MakeFullControlledToffoliDD_TargetBottom)->Apply(qubitRange); // NOLINT
 
 static void BM_MakeSWAPDD(benchmark::State& state) {
-    auto nqubits = state.range(0);
+    dd::QubitCount nqubits = state.range(0);
     auto dd      = std::make_unique<dd::Package<>>(nqubits);
 
-    for (auto _: state) {
+    for ([[maybe_unused]]  auto _: state) {
         auto sv = dd->makeGateDD(dd::Xmat, nqubits, dd::Control{static_cast<dd::Qubit>(nqubits - 1)}, 0);
         sv      = dd->multiply(sv, dd->multiply(dd->makeGateDD(dd::Xmat, nqubits, 0_pc, static_cast<dd::Qubit>(nqubits - 1)), sv));
 
@@ -198,97 +202,97 @@ static void BM_MakeSWAPDD(benchmark::State& state) {
         dd->clearComputeTables();
     }
 }
-BENCHMARK(BM_MakeSWAPDD)->Apply(QubitRange);
+BENCHMARK(BM_MakeSWAPDD)->Apply(qubitRange); // NOLINT
 
 ///
 /// Test multiplication
 ///
 
-static void BM_MxV_X(benchmark::State& state) {
-    auto nqubits = state.range(0);
+static void bmMxVX(benchmark::State& state) {
+    dd::QubitCount nqubits = state.range(0);
     auto dd      = std::make_unique<dd::Package<>>(nqubits);
     auto zero    = dd->makeZeroState(nqubits);
     auto x       = dd->makeGateDD(dd::Xmat, nqubits, 0);
 
-    for (auto _: state) {
+    for ([[maybe_unused]]  auto _: state) {
         auto sim = dd->multiply(x, zero);
         benchmark::DoNotOptimize(sim);
         // clear compute table so the next iteration does not find the result cached
         dd->clearComputeTables();
     }
 }
-BENCHMARK(BM_MxV_X)->Apply(QubitRange);
+BENCHMARK(bmMxVX)->Apply(qubitRange); // NOLINT
 
-static void BM_MxV_H(benchmark::State& state) {
-    auto nqubits = state.range(0);
+static void bmMxVH(benchmark::State& state) {
+    dd::QubitCount nqubits = state.range(0);
     auto dd      = std::make_unique<dd::Package<>>(nqubits);
     auto zero    = dd->makeZeroState(nqubits);
     auto h       = dd->makeGateDD(dd::Hmat, nqubits, 0);
 
-    for (auto _: state) {
+    for ([[maybe_unused]]  auto _: state) {
         auto sim = dd->multiply(h, zero);
         benchmark::DoNotOptimize(sim);
         // clear compute table so the next iteration does not find the result cached
         dd->clearComputeTables();
     }
 }
-BENCHMARK(BM_MxV_H)->Apply(QubitRange);
+BENCHMARK(bmMxVH)->Apply(qubitRange); // NOLINT
 
-static void BM_MxV_T(benchmark::State& state) {
-    auto nqubits = state.range(0);
+static void bmMxVT(benchmark::State& state) {
+    dd::QubitCount nqubits = state.range(0);
     auto dd      = std::make_unique<dd::Package<>>(nqubits);
     auto zero    = dd->makeZeroState(nqubits);
     auto t       = dd->makeGateDD(dd::Tmat, nqubits, 0);
 
-    for (auto _: state) {
+    for ([[maybe_unused]]  auto _: state) {
         auto sim = dd->multiply(t, zero);
         benchmark::DoNotOptimize(sim);
         // clear compute table so the next iteration does not find the result cached
         dd->clearComputeTables();
     }
 }
-BENCHMARK(BM_MxV_T)->Apply(QubitRange);
+BENCHMARK(bmMxVT)->Apply(qubitRange); // NOLINT
 
-static void BM_MxV_CX_ControlTop_TargetBottom(benchmark::State& state) {
-    unsigned short nqubits     = state.range(0);
+static void bmMxVCxControlTopTargetBottom(benchmark::State& state) {
+    dd::QubitCount nqubits     = state.range(0);
     auto           dd          = std::make_unique<dd::Package<>>(nqubits);
     auto           basisStates = std::vector<dd::BasisStates>{nqubits, dd::BasisStates::zero};
     basisStates[nqubits - 1]   = dd::BasisStates::plus;
     auto plus                  = dd->makeBasisState(nqubits, basisStates);
     auto cx                    = dd->makeGateDD(dd::Xmat, nqubits, dd::Control{static_cast<dd::Qubit>(nqubits - 1)}, 0);
 
-    for (auto _: state) {
+    for ([[maybe_unused]]  auto _: state) {
         auto sim = dd->multiply(cx, plus);
         benchmark::DoNotOptimize(sim);
         // clear compute table so the next iteration does not find the result cached
         dd->clearComputeTables();
     }
 }
-BENCHMARK(BM_MxV_CX_ControlTop_TargetBottom)->Apply(QubitRange);
+BENCHMARK(bmMxVCxControlTopTargetBottom)->Apply(qubitRange); // NOLINT
 
-static void BM_MxV_CX_ControlBottom_TargetTop(benchmark::State& state) {
-    unsigned short nqubits     = state.range(0);
+static void bmMxVCxControlBottomTargetTop(benchmark::State& state) {
+    dd::QubitCount nqubits     = state.range(0);
     auto           dd          = std::make_unique<dd::Package<>>(nqubits);
     auto           basisStates = std::vector<dd::BasisStates>{nqubits, dd::BasisStates::zero};
     basisStates[0]             = dd::BasisStates::plus;
     auto plus                  = dd->makeBasisState(nqubits, basisStates);
     auto cx                    = dd->makeGateDD(dd::Xmat, nqubits, 0_pc, static_cast<dd::Qubit>(nqubits - 1));
 
-    for (auto _: state) {
+    for ([[maybe_unused]]  auto _: state) {
         auto sim = dd->multiply(cx, plus);
         benchmark::DoNotOptimize(sim);
         // clear compute table so the next iteration does not find the result cached
         dd->clearComputeTables();
     }
 }
-BENCHMARK(BM_MxV_CX_ControlBottom_TargetTop)->Apply(QubitRange);
+BENCHMARK(bmMxVCxControlBottomTargetTop)->Apply(qubitRange); // NOLINT
 
-static void BM_MxV_HadamardLayer(benchmark::State& state) {
-    auto nqubits = state.range(0);
+static void bmMxVHadamardLayer(benchmark::State& state) {
+    dd::QubitCount nqubits = state.range(0);
     auto dd      = std::make_unique<dd::Package<>>(nqubits);
     auto zero    = dd->makeZeroState(nqubits);
 
-    for (auto _: state) {
+    for ([[maybe_unused]]  auto _: state) {
         auto sv = zero;
         for (int i = 0; i < nqubits; ++i) {
             auto h = dd->makeGateDD(dd::Hmat, nqubits, static_cast<dd::Qubit>(i));
@@ -298,15 +302,15 @@ static void BM_MxV_HadamardLayer(benchmark::State& state) {
         dd->clearComputeTables();
     }
 }
-BENCHMARK(BM_MxV_HadamardLayer)->Apply(QubitRange);
+BENCHMARK(bmMxVHadamardLayer)->Apply(qubitRange); // NOLINT
 
-static void BM_MxV_GHZ(benchmark::State& state) {
-    auto nqubits = state.range(0);
+static void bmMxVGhz(benchmark::State& state) {
+    dd::QubitCount nqubits = state.range(0);
     auto dd      = std::make_unique<dd::Package<>>(nqubits);
     auto zero    = dd->makeZeroState(nqubits);
     auto h       = dd->makeGateDD(dd::Hmat, nqubits, static_cast<dd::Qubit>(nqubits - 1));
 
-    for (auto _: state) {
+    for ([[maybe_unused]]  auto _: state) {
         auto sv = zero;
         sv      = dd->multiply(h, sv);
         for (auto i = static_cast<int>(nqubits - 2); i >= 0; --i) {
@@ -317,28 +321,28 @@ static void BM_MxV_GHZ(benchmark::State& state) {
         dd->clearComputeTables();
     }
 }
-BENCHMARK(BM_MxV_GHZ)->Apply(QubitRange);
+BENCHMARK(bmMxVGhz)->Apply(qubitRange); // NOLINT
 
-static void BM_MxM_Bell(benchmark::State& state) {
-    auto nqubits = state.range(0);
+static void bmMxMBell(benchmark::State& state) {
+    dd::QubitCount nqubits = state.range(0);
     auto dd      = std::make_unique<dd::Package<>>(nqubits);
     auto h       = dd->makeGateDD(dd::Hmat, nqubits, static_cast<dd::Qubit>(nqubits - 1));
     auto cx      = dd->makeGateDD(dd::Xmat, nqubits, dd::Control{static_cast<dd::Qubit>(nqubits - 1)}, 0);
 
-    for (auto _: state) {
+    for ([[maybe_unused]]  auto _: state) {
         auto bell = dd->multiply(cx, h);
         benchmark::DoNotOptimize(bell);
         // clear compute table so the next iteration does not find the result cached
         dd->clearComputeTables();
     }
 }
-BENCHMARK(BM_MxM_Bell)->Apply(QubitRange);
+BENCHMARK(bmMxMBell)->Apply(qubitRange); // NOLINT
 
-static void BM_MxM_GHZ(benchmark::State& state) {
-    auto nqubits = state.range(0);
+static void bmMxMGhz(benchmark::State& state) {
+    dd::QubitCount nqubits = state.range(0);
     auto dd      = std::make_unique<dd::Package<>>(nqubits);
 
-    for (auto _: state) {
+    for ([[maybe_unused]]  auto _: state) {
         auto func = dd->makeGateDD(dd::Hmat, nqubits, static_cast<dd::Qubit>(nqubits - 1));
         for (auto i = static_cast<int>(nqubits - 2); i >= 0; --i) {
             auto cx = dd->makeGateDD(dd::Xmat, nqubits, dd::Control{static_cast<dd::Qubit>(nqubits - 1)}, static_cast<dd::Qubit>(i));
@@ -348,26 +352,26 @@ static void BM_MxM_GHZ(benchmark::State& state) {
         dd->clearComputeTables();
     }
 }
-BENCHMARK(BM_MxM_GHZ)->Apply(QubitRange);
+BENCHMARK(bmMxMGhz)->Apply(qubitRange); // NOLINT
 
-static void BM_vUniqueTableGet(benchmark::State& state) {
+static void bmVUniqueTableGet(benchmark::State& state) {
     auto allocs = state.range(0);
-    for (auto _: state) {
+    for ([[maybe_unused]]  auto _: state) {
         auto dd = std::make_unique<dd::Package<>>(1);
         for (int i = 0; i < allocs; ++i) {
-            auto p = dd->vUniqueTable.getNode();
+            auto *p = dd->vUniqueTable.getNode();
             benchmark::DoNotOptimize(p);
         }
     }
 }
-BENCHMARK(BM_vUniqueTableGet)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(10, 10000000);
+BENCHMARK(bmVUniqueTableGet)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(10, 10000000); // NOLINT
 
-static void BM_vUniqueTableGetAndReturn(benchmark::State& state) {
+static void bmVUniqueTableGetAndReturn(benchmark::State& state) {
     auto allocs = state.range(0);
-    for (auto _: state) {
+    for ([[maybe_unused]]  auto _: state) {
         auto dd = std::make_unique<dd::Package<>>(1);
         for (int i = 0; i < allocs; ++i) {
-            auto p = dd->vUniqueTable.getNode();
+            auto *p = dd->vUniqueTable.getNode();
             benchmark::DoNotOptimize(p);
             if (i % 5 == 0) {
                 dd->vUniqueTable.returnNode(p);
@@ -375,14 +379,14 @@ static void BM_vUniqueTableGetAndReturn(benchmark::State& state) {
         }
     }
 }
-BENCHMARK(BM_vUniqueTableGetAndReturn)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(10, 10000000);
+BENCHMARK(bmVUniqueTableGetAndReturn)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(10, 10000000); // NOLINT
 
-static void BM_mUniqueTableGet(benchmark::State& state) {
+static void bmMUniqueTableGet(benchmark::State& state) {
     auto allocs = state.range(0);
-    for (auto _: state) {
+    for ([[maybe_unused]]  auto _: state) {
         auto dd = std::make_unique<dd::Package<>>(1);
         for (int i = 0; i < allocs; ++i) {
-            auto p = dd->mUniqueTable.getNode();
+            auto *p = dd->mUniqueTable.getNode();
             benchmark::DoNotOptimize(p);
             if (i % 5 == 0) {
                 dd->mUniqueTable.returnNode(p);
@@ -390,14 +394,14 @@ static void BM_mUniqueTableGet(benchmark::State& state) {
         }
     }
 }
-BENCHMARK(BM_mUniqueTableGet)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(10, 10000000);
+BENCHMARK(bmMUniqueTableGet)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(10, 10000000); // NOLINT
 
-static void BM_mUniqueTableGetAndReturn(benchmark::State& state) {
+static void bmMUniqueTableGetAndReturn(benchmark::State& state) {
     auto allocs = state.range(0);
-    for (auto _: state) {
+    for ([[maybe_unused]]  auto _: state) {
         auto dd = std::make_unique<dd::Package<>>(1);
         for (int i = 0; i < allocs; ++i) {
-            auto p = dd->mUniqueTable.getNode();
+            auto *p = dd->mUniqueTable.getNode();
             benchmark::DoNotOptimize(p);
             if (i % 5 == 0) {
                 dd->mUniqueTable.returnNode(p);
@@ -405,4 +409,4 @@ static void BM_mUniqueTableGetAndReturn(benchmark::State& state) {
         }
     }
 }
-BENCHMARK(BM_mUniqueTableGetAndReturn)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(10, 10000000);
+BENCHMARK(bmMUniqueTableGetAndReturn)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(10, 10000000); // NOLINT

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -12,44 +12,44 @@
 
 using namespace dd::literals;
 
-auto BellCicuit1(std::unique_ptr<dd::Package<>>& dd) {
+auto bellCicuit1(std::unique_ptr<dd::Package<>>& dd) {
     /***** define Hadamard gate acting on q0 *****/
-    auto h_gate = dd->makeGateDD(dd::Hmat, 2, 0);
+    auto hGate = dd->makeGateDD(dd::Hmat, 2, 0);
 
     /***** define cx gate with control q0 and target q1 *****/
-    auto cx_gate = dd->makeGateDD(dd::Xmat, 2, 0_pc, 1);
+    auto cxGate = dd->makeGateDD(dd::Xmat, 2, 0_pc, 1);
 
     //Multiply matrices to get functionality of circuit
-    return dd->multiply(cx_gate, h_gate);
+    return dd->multiply(cxGate, hGate);
 }
 
-auto BellCicuit2(std::unique_ptr<dd::Package<>>& dd) {
+auto bellCicuit2(std::unique_ptr<dd::Package<>>& dd) {
     /***** define Hadamard gate acting on q1 *****/
-    auto h_gate_q1 = dd->makeGateDD(dd::Hmat, 2, 1);
+    auto hGateQ1 = dd->makeGateDD(dd::Hmat, 2, 1);
 
     /***** define Hadamard gate acting on q0 *****/
-    auto h_gate_q0 = dd->makeGateDD(dd::Hmat, 2, 0);
+    auto hGateQ0 = dd->makeGateDD(dd::Hmat, 2, 0);
 
     /***** define cx gate with control q1 and target q0 *****/
-    auto cx_gate = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
+    auto cxGate = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
 
     //Multiply matrices to get functionality of circuit
-    return dd->multiply(dd->multiply(h_gate_q1, h_gate_q0), dd->multiply(cx_gate, h_gate_q1));
+    return dd->multiply(dd->multiply(hGateQ1, hGateQ0), dd->multiply(cxGate, hGateQ1));
 }
 
-int main() {
+int main() { // NOLINT(bugprone-exception-escape)
     dd::Package<>::printInformation(); // uncomment to print various sizes of structs and arrays
     //Initialize package
     auto dd = std::make_unique<dd::Package<>>(4);
 
     // create Bell circuit 1
-    auto bell_circuit1 = BellCicuit1(dd);
+    auto bellCircuit1 = bellCicuit1(dd);
 
     // create Bell circuit 2
-    auto bell_circuit2 = BellCicuit2(dd);
+    auto bellCircuit2 = bellCicuit2(dd);
 
     /***** Equivalence checking *****/
-    if (bell_circuit1 == bell_circuit2) {
+    if (bellCircuit1 == bellCircuit2) {
         std::cout << "Circuits are equal!" << std::endl;
     } else {
         std::cout << "Circuits are not equal!" << std::endl;
@@ -57,17 +57,17 @@ int main() {
 
     /***** Simulation *****/
     //Generate vector in basis state |00>
-    auto zero_state = dd->makeZeroState(2);
+    auto zeroState = dd->makeZeroState(2);
 
     //Simulate the bell_circuit with initial state |00>
-    auto bell_state  = dd->multiply(bell_circuit1, zero_state);
-    auto bell_state2 = dd->multiply(bell_circuit2, zero_state);
+    auto bellState  = dd->multiply(bellCircuit1, zeroState);
+    auto bellState2 = dd->multiply(bellCircuit2, zeroState);
 
     //print result
-    dd->printVector(bell_state);
+    dd->printVector(bellState);
 
-    std::cout << "Bell states have a fidelity of " << dd->fidelity(bell_state, bell_state2) << "\n";
-    std::cout << "Bell state and zero state have a fidelity of " << dd->fidelity(bell_state, zero_state) << "\n";
+    std::cout << "Bell states have a fidelity of " << dd->fidelity(bellState, bellState2) << "\n";
+    std::cout << "Bell state and zero state have a fidelity of " << dd->fidelity(bellState, zeroState) << "\n";
 
     /***** Custom gates *****/
     // define, e.g., Pauli-Z matrix
@@ -77,8 +77,8 @@ int main() {
     m[2] = {0., 0.};
     m[3] = {-1., 0.};
 
-    auto my_z_gate = dd->makeGateDD(m, 1, 0);
-    std::cout << "DD of my gate has size " << dd->size(my_z_gate) << std::endl;
+    auto myZGate = dd->makeGateDD(m, 1, 0);
+    std::cout << "DD of my gate has size " << dd->size(myZGate) << std::endl;
 
     // compute (partial) traces
     auto partTrace = dd->partialTrace(dd->makeIdent(2), {true, true});
@@ -86,9 +86,9 @@ int main() {
     std::cout << "Identity function for 4 qubits has trace: " << fullTrace << std::endl;
 
     /***** print DDs as SVG file *****/
-    dd::export2Dot(bell_circuit1, "bell_circuit1.dot", false);
-    dd::export2Dot(bell_circuit2, "bell_circuit2.dot");
-    dd::export2Dot(bell_state, "bell_state.dot", true);
+    dd::export2Dot(bellCircuit1, "bell_circuit1.dot", false);
+    dd::export2Dot(bellCircuit2, "bell_circuit2.dot");
+    dd::export2Dot(bellState, "bell_state.dot", true);
     dd::export2Dot(partTrace, "partial_trace.dot");
 
     /***** print statistics *****/

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -37,7 +37,7 @@ auto bellCicuit2(std::unique_ptr<dd::Package<>>& dd) {
     return dd->multiply(dd->multiply(hGateQ1, hGateQ0), dd->multiply(cxGate, hGateQ1));
 }
 
-int main() { // NOLINT(bugprone-exception-escape)
+int main() {                           // NOLINT(bugprone-exception-escape)
     dd::Package<>::printInformation(); // uncomment to print various sizes of structs and arrays
     //Initialize package
     auto dd = std::make_unique<dd::Package<>>(4);

--- a/test/test_package.cpp
+++ b/test/test_package.cpp
@@ -23,61 +23,61 @@ TEST(DDPackageTest, TrivialTest) {
     auto dd = std::make_unique<dd::Package<>>(2);
     EXPECT_EQ(dd->qubits(), 2);
 
-    auto x_gate = dd->makeGateDD(dd::Xmat, 1, 0);
-    auto h_gate = dd->makeGateDD(dd::Hmat, 1, 0);
+    auto xGate = dd->makeGateDD(dd::Xmat, 1, 0);
+    auto hGate = dd->makeGateDD(dd::Hmat, 1, 0);
 
-    ASSERT_EQ(dd->getValueByPath(h_gate, "0"), (dd::ComplexValue{dd::SQRT2_2, 0}));
+    ASSERT_EQ(dd->getValueByPath(hGate, "0"), (dd::ComplexValue{dd::SQRT2_2, 0}));
 
-    auto zero_state = dd->makeZeroState(1);
-    auto h_state    = dd->multiply(h_gate, zero_state);
-    auto one_state  = dd->multiply(x_gate, zero_state);
+    auto zeroState = dd->makeZeroState(1);
+    auto hState    = dd->multiply(hGate, zeroState);
+    auto oneState  = dd->multiply(xGate, zeroState);
 
-    ASSERT_EQ(dd->fidelity(zero_state, one_state), 0.0);
+    ASSERT_EQ(dd->fidelity(zeroState, oneState), 0.0);
     // repeat the same calculation - triggering compute table hit
-    ASSERT_EQ(dd->fidelity(zero_state, one_state), 0.0);
-    ASSERT_NEAR(dd->fidelity(zero_state, h_state), 0.5, dd::ComplexTable<>::tolerance());
-    ASSERT_NEAR(dd->fidelity(one_state, h_state), 0.5, dd::ComplexTable<>::tolerance());
+    ASSERT_EQ(dd->fidelity(zeroState, oneState), 0.0);
+    ASSERT_NEAR(dd->fidelity(zeroState, hState), 0.5, dd::ComplexTable<>::tolerance());
+    ASSERT_NEAR(dd->fidelity(oneState, hState), 0.5, dd::ComplexTable<>::tolerance());
 }
 
 TEST(DDPackageTest, BellState) {
     auto dd = std::make_unique<dd::Package<>>(2);
 
-    auto h_gate     = dd->makeGateDD(dd::Hmat, 2, 1);
-    auto cx_gate    = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
-    auto zero_state = dd->makeZeroState(2);
+    auto hGate     = dd->makeGateDD(dd::Hmat, 2, 1);
+    auto cxGate    = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
+    auto zeroState = dd->makeZeroState(2);
 
-    auto bell_state = dd->multiply(dd->multiply(cx_gate, h_gate), zero_state);
-    dd->printVector(bell_state);
+    auto bellState = dd->multiply(dd->multiply(cxGate, hGate), zeroState);
+    dd->printVector(bellState);
 
     // repeated calculation is practically for free
-    auto bell_state2 = dd->multiply(dd->multiply(cx_gate, h_gate), zero_state);
-    EXPECT_EQ(bell_state, bell_state2);
+    auto bellState2 = dd->multiply(dd->multiply(cxGate, hGate), zeroState);
+    EXPECT_EQ(bellState, bellState2);
 
-    ASSERT_EQ(dd->getValueByPath(bell_state, "00"), (dd::ComplexValue{dd::SQRT2_2, 0}));
-    ASSERT_EQ(dd->getValueByPath(bell_state, "01"), (dd::ComplexValue{0, 0}));
-    ASSERT_EQ(dd->getValueByPath(bell_state, "10"), (dd::ComplexValue{0, 0}));
-    ASSERT_EQ(dd->getValueByPath(bell_state, "11"), (dd::ComplexValue{dd::SQRT2_2, 0}));
+    ASSERT_EQ(dd->getValueByPath(bellState, "00"), (dd::ComplexValue{dd::SQRT2_2, 0}));
+    ASSERT_EQ(dd->getValueByPath(bellState, "01"), (dd::ComplexValue{0, 0}));
+    ASSERT_EQ(dd->getValueByPath(bellState, "10"), (dd::ComplexValue{0, 0}));
+    ASSERT_EQ(dd->getValueByPath(bellState, "11"), (dd::ComplexValue{dd::SQRT2_2, 0}));
 
-    ASSERT_EQ(dd->getValueByPath(bell_state, 0), (dd::ComplexValue{dd::SQRT2_2, 0}));
-    ASSERT_EQ(dd->getValueByPath(bell_state, 1), (dd::ComplexValue{0, 0}));
-    ASSERT_EQ(dd->getValueByPath(bell_state, 2), (dd::ComplexValue{0, 0}));
-    ASSERT_EQ(dd->getValueByPath(bell_state, 3), (dd::ComplexValue{dd::SQRT2_2, 0}));
+    ASSERT_EQ(dd->getValueByPath(bellState, 0), (dd::ComplexValue{dd::SQRT2_2, 0}));
+    ASSERT_EQ(dd->getValueByPath(bellState, 1), (dd::ComplexValue{0, 0}));
+    ASSERT_EQ(dd->getValueByPath(bellState, 2), (dd::ComplexValue{0, 0}));
+    ASSERT_EQ(dd->getValueByPath(bellState, 3), (dd::ComplexValue{dd::SQRT2_2, 0}));
 
-    auto goal_state = dd::CVec{{dd::SQRT2_2, 0.}, {0., 0.}, {0., 0.}, {dd::SQRT2_2, 0.}};
-    ASSERT_EQ(dd->getVector(bell_state), goal_state);
+    auto goalState = dd::CVec{{dd::SQRT2_2, 0.}, {0., 0.}, {0., 0.}, {dd::SQRT2_2, 0.}};
+    ASSERT_EQ(dd->getVector(bellState), goalState);
 
-    ASSERT_DOUBLE_EQ(dd->fidelity(zero_state, bell_state), 0.5);
+    ASSERT_DOUBLE_EQ(dd->fidelity(zeroState, bellState), 0.5);
 
-    export2Dot(bell_state, "bell_state_colored_labels.dot", true, true, false, false, false);
-    export2Dot(bell_state, "bell_state_colored_labels_classic.dot", true, true, true, false, false);
-    export2Dot(bell_state, "bell_state_mono_labels.dot", false, true, false, false, false);
-    export2Dot(bell_state, "bell_state_mono_labels_classic.dot", false, true, true, false, false);
-    export2Dot(bell_state, "bell_state_colored.dot", true, false, false, false, false);
-    export2Dot(bell_state, "bell_state_colored_classic.dot", true, false, true, false, false);
-    export2Dot(bell_state, "bell_state_mono.dot", false, false, false, false, false);
-    export2Dot(bell_state, "bell_state_mono_classic.dot", false, false, true, false, false);
-    export2Dot(bell_state, "bell_state_memory.dot", false, true, true, true, false);
-    dd::exportEdgeWeights(bell_state, std::cout);
+    export2Dot(bellState, "bell_state_colored_labels.dot", true, true, false, false, false);
+    export2Dot(bellState, "bell_state_colored_labels_classic.dot", true, true, true, false, false);
+    export2Dot(bellState, "bell_state_mono_labels.dot", false, true, false, false, false);
+    export2Dot(bellState, "bell_state_mono_labels_classic.dot", false, true, true, false, false);
+    export2Dot(bellState, "bell_state_colored.dot", true, false, false, false, false);
+    export2Dot(bellState, "bell_state_colored_classic.dot", true, false, true, false, false);
+    export2Dot(bellState, "bell_state_mono.dot", false, false, false, false, false);
+    export2Dot(bellState, "bell_state_mono_classic.dot", false, false, true, false, false);
+    export2Dot(bellState, "bell_state_memory.dot", false, true, true, true, false);
+    dd::exportEdgeWeights(bellState, std::cout);
 
     dd->statistics();
 }
@@ -85,60 +85,60 @@ TEST(DDPackageTest, BellState) {
 TEST(DDPackageTest, QFTState) {
     auto dd = std::make_unique<dd::Package<>>(3);
 
-    auto h0_gate   = dd->makeGateDD(dd::Hmat, 3, 0);
-    auto s0_gate   = dd->makeGateDD(dd::Smat, 3, 1_pc, 0);
-    auto t0_gate   = dd->makeGateDD(dd::Tmat, 3, 2_pc, 0);
-    auto h1_gate   = dd->makeGateDD(dd::Hmat, 3, 1);
-    auto s1_gate   = dd->makeGateDD(dd::Smat, 3, 2_pc, 1);
-    auto h2_gate   = dd->makeGateDD(dd::Hmat, 3, 2);
-    auto swap_gate = dd->makeSWAPDD(3, {}, 0, 2);
+    auto h0Gate   = dd->makeGateDD(dd::Hmat, 3, 0);
+    auto s0Gate   = dd->makeGateDD(dd::Smat, 3, 1_pc, 0);
+    auto t0Gate   = dd->makeGateDD(dd::Tmat, 3, 2_pc, 0);
+    auto h1Gate   = dd->makeGateDD(dd::Hmat, 3, 1);
+    auto s1Gate   = dd->makeGateDD(dd::Smat, 3, 2_pc, 1);
+    auto h2Gate   = dd->makeGateDD(dd::Hmat, 3, 2);
+    auto swapGate = dd->makeSWAPDD(3, {}, 0, 2);
 
-    auto qft_op = dd->multiply(s0_gate, h0_gate);
-    qft_op      = dd->multiply(t0_gate, qft_op);
-    qft_op      = dd->multiply(h1_gate, qft_op);
-    qft_op      = dd->multiply(s1_gate, qft_op);
-    qft_op      = dd->multiply(h2_gate, qft_op);
+    auto qftOp = dd->multiply(s0Gate, h0Gate);
+    qftOp      = dd->multiply(t0Gate, qftOp);
+    qftOp      = dd->multiply(h1Gate, qftOp);
+    qftOp      = dd->multiply(s1Gate, qftOp);
+    qftOp      = dd->multiply(h2Gate, qftOp);
 
-    qft_op         = dd->multiply(swap_gate, qft_op);
-    auto qft_state = dd->multiply(qft_op, dd->makeZeroState(3));
+    qftOp         = dd->multiply(swapGate, qftOp);
+    auto qftState = dd->multiply(qftOp, dd->makeZeroState(3));
 
-    dd->printVector(qft_state);
+    dd->printVector(qftState);
 
     for (dd::Qubit qubit = 0; qubit < 7; ++qubit) {
-        ASSERT_NEAR(dd->getValueByPath(qft_state, qubit).r, static_cast<dd::fp>(0.5) * dd::SQRT2_2, dd->cn.complexTable.tolerance());
-        ASSERT_EQ(dd->getValueByPath(qft_state, qubit).i, 0);
+        ASSERT_NEAR(dd->getValueByPath(qftState, qubit).r, static_cast<dd::fp>(0.5) * dd::SQRT2_2, dd->cn.complexTable.tolerance());
+        ASSERT_EQ(dd->getValueByPath(qftState, qubit).i, 0);
     }
 
-    export2Dot(qft_state, "qft_state_colored_labels.dot", true, true, false, false, false);
-    export2Dot(qft_state, "qft_state_colored_labels_classic.dot", true, true, true, false, false);
-    export2Dot(qft_state, "qft_state_mono_labels.dot", false, true, false, false, false);
-    export2Dot(qft_state, "qft_state_mono_labels_classic.dot", false, true, true, false, false);
-    export2Dot(qft_state, "qft_state_colored.dot", true, false, false, false, false);
-    export2Dot(qft_state, "qft_state_colored_classic.dot", true, false, true, false, false);
-    export2Dot(qft_state, "qft_state_mono.dot", false, false, false, false, false);
-    export2Dot(qft_state, "qft_state_mono_classic.dot", false, false, true, false, false);
-    export2Dot(qft_state, "qft_state_memory.dot", false, true, true, true, false);
-    dd::exportEdgeWeights(qft_state, std::cout);
+    export2Dot(qftState, "qft_state_colored_labels.dot", true, true, false, false, false);
+    export2Dot(qftState, "qft_state_colored_labels_classic.dot", true, true, true, false, false);
+    export2Dot(qftState, "qft_state_mono_labels.dot", false, true, false, false, false);
+    export2Dot(qftState, "qft_state_mono_labels_classic.dot", false, true, true, false, false);
+    export2Dot(qftState, "qft_state_colored.dot", true, false, false, false, false);
+    export2Dot(qftState, "qft_state_colored_classic.dot", true, false, true, false, false);
+    export2Dot(qftState, "qft_state_mono.dot", false, false, false, false, false);
+    export2Dot(qftState, "qft_state_mono_classic.dot", false, false, true, false, false);
+    export2Dot(qftState, "qft_state_memory.dot", false, true, true, true, false);
+    dd::exportEdgeWeights(qftState, std::cout);
 
-    export2Dot(qft_op, "qft_op_polar_colored_labels.dot", true, true, false, false, false, true);
-    export2Dot(qft_op, "qft_op_polar_colored_labels_classic.dot", true, true, true, false, false, true);
-    export2Dot(qft_op, "qft_op_polar_mono_labels.dot", false, true, false, false, false, true);
-    export2Dot(qft_op, "qft_op_polar_mono_labels_classic.dot", false, true, true, false, false, true);
-    export2Dot(qft_op, "qft_op_polar_colored.dot", true, false, false, false, false, true);
-    export2Dot(qft_op, "qft_op_polar_colored_classic.dot", true, false, true, false, false, true);
-    export2Dot(qft_op, "qft_op_polar_mono.dot", false, false, false, false, false, true);
-    export2Dot(qft_op, "qft_op_polar_mono_classic.dot", false, false, true, false, false, true);
-    export2Dot(qft_op, "qft_op_polar_memory.dot", false, true, true, true, false, true);
+    export2Dot(qftOp, "qft_op_polar_colored_labels.dot", true, true, false, false, false, true);
+    export2Dot(qftOp, "qft_op_polar_colored_labels_classic.dot", true, true, true, false, false, true);
+    export2Dot(qftOp, "qft_op_polar_mono_labels.dot", false, true, false, false, false, true);
+    export2Dot(qftOp, "qft_op_polar_mono_labels_classic.dot", false, true, true, false, false, true);
+    export2Dot(qftOp, "qft_op_polar_colored.dot", true, false, false, false, false, true);
+    export2Dot(qftOp, "qft_op_polar_colored_classic.dot", true, false, true, false, false, true);
+    export2Dot(qftOp, "qft_op_polar_mono.dot", false, false, false, false, false, true);
+    export2Dot(qftOp, "qft_op_polar_mono_classic.dot", false, false, true, false, false, true);
+    export2Dot(qftOp, "qft_op_polar_memory.dot", false, true, true, true, false, true);
 
-    export2Dot(qft_op, "qft_op_rectangular_colored_labels.dot", true, true, false, false, false, false);
-    export2Dot(qft_op, "qft_op_rectangular_colored_labels_classic.dot", true, true, true, false, false, false);
-    export2Dot(qft_op, "qft_op_rectangular_mono_labels.dot", false, true, false, false, false, false);
-    export2Dot(qft_op, "qft_op_rectangular_mono_labels_classic.dot", false, true, true, false, false, false);
-    export2Dot(qft_op, "qft_op_rectangular_colored.dot", true, false, false, false, false, false);
-    export2Dot(qft_op, "qft_op_rectangular_colored_classic.dot", true, false, true, false, false, false);
-    export2Dot(qft_op, "qft_op_rectangular_mono.dot", false, false, false, false, false, false);
-    export2Dot(qft_op, "qft_op_rectangular_mono_classic.dot", false, false, true, false, false, false);
-    export2Dot(qft_op, "qft_op_rectangular_memory.dot", false, true, true, true, false, false);
+    export2Dot(qftOp, "qft_op_rectangular_colored_labels.dot", true, true, false, false, false, false);
+    export2Dot(qftOp, "qft_op_rectangular_colored_labels_classic.dot", true, true, true, false, false, false);
+    export2Dot(qftOp, "qft_op_rectangular_mono_labels.dot", false, true, false, false, false, false);
+    export2Dot(qftOp, "qft_op_rectangular_mono_labels_classic.dot", false, true, true, false, false, false);
+    export2Dot(qftOp, "qft_op_rectangular_colored.dot", true, false, false, false, false, false);
+    export2Dot(qftOp, "qft_op_rectangular_colored_classic.dot", true, false, true, false, false, false);
+    export2Dot(qftOp, "qft_op_rectangular_mono.dot", false, false, false, false, false, false);
+    export2Dot(qftOp, "qft_op_rectangular_mono_classic.dot", false, false, true, false, false, false);
+    export2Dot(qftOp, "qft_op_rectangular_memory.dot", false, true, true, true, false, false);
 
     dd->statistics();
 }
@@ -146,30 +146,30 @@ TEST(DDPackageTest, QFTState) {
 TEST(DDPackageTest, CorruptedBellState) {
     auto dd = std::make_unique<dd::Package<>>(2);
 
-    auto h_gate     = dd->makeGateDD(dd::Hmat, 2, 1);
-    auto cx_gate    = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
-    auto zero_state = dd->makeZeroState(2);
+    auto hGate     = dd->makeGateDD(dd::Hmat, 2, 1);
+    auto cxGate    = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
+    auto zeroState = dd->makeZeroState(2);
 
-    auto bell_state = dd->multiply(dd->multiply(cx_gate, h_gate), zero_state);
+    auto bellState = dd->multiply(dd->multiply(cxGate, hGate), zeroState);
 
-    bell_state.w = dd->cn.getTemporary(0.5, 0);
+    bellState.w = dd->cn.getTemporary(0.5, 0);
     // prints a warning
-    std::mt19937_64 mt;
-    std::cout << dd->measureAll(bell_state, false, mt) << "\n";
+    std::mt19937_64 mt; // NOLINT(cert-msc51-cpp)
+    std::cout << dd->measureAll(bellState, false, mt) << "\n";
 
-    bell_state.w = dd::Complex::zero;
+    bellState.w = dd::Complex::zero;
 
-    ASSERT_THROW(dd->measureAll(bell_state, false, mt), std::runtime_error);
+    ASSERT_THROW(dd->measureAll(bellState, false, mt), std::runtime_error);
 
-    ASSERT_THROW(dd->measureOneCollapsing(bell_state, 0, true, mt), std::runtime_error);
+    ASSERT_THROW(dd->measureOneCollapsing(bellState, 0, true, mt), std::runtime_error);
 }
 
 TEST(DDPackageTest, NegativeControl) {
     auto dd = std::make_unique<dd::Package<>>(2);
 
-    auto x_gate     = dd->makeGateDD(dd::Xmat, 2, 1_nc, 0);
-    auto zero_state = dd->makeZeroState(2);
-    auto state01    = dd->multiply(x_gate, zero_state);
+    auto xGate     = dd->makeGateDD(dd::Xmat, 2, 1_nc, 0);
+    auto zeroState = dd->makeZeroState(2);
+    auto state01    = dd->multiply(xGate, zeroState);
     EXPECT_EQ(dd->getValueByPath(state01, 0b01).r, 1.);
 }
 
@@ -188,7 +188,7 @@ TEST(DDPackageTest, PartialIdentityTrace) {
 }
 
 TEST(DDPackageTest, StateGenerationManipulation) {
-    unsigned short nqubits = 6;
+    std::size_t nqubits = 6;
     auto           dd      = std::make_unique<dd::Package<>>(nqubits);
     auto           b       = std::vector<bool>(nqubits, false);
     b[0] = b[1] = true;
@@ -206,70 +206,70 @@ TEST(DDPackageTest, StateGenerationManipulation) {
 TEST(DDPackageTest, VectorSerializationTest) {
     auto dd = std::make_unique<dd::Package<>>(2);
 
-    auto h_gate     = dd->makeGateDD(dd::Hmat, 2, 1);
-    auto cx_gate    = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
-    auto zero_state = dd->makeZeroState(2);
+    auto hGate     = dd->makeGateDD(dd::Hmat, 2, 1);
+    auto cxGate    = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
+    auto zeroState = dd->makeZeroState(2);
 
-    auto bell_state = dd->multiply(dd->multiply(cx_gate, h_gate), zero_state);
+    auto bellState = dd->multiply(dd->multiply(cxGate, hGate), zeroState);
 
-    serialize(bell_state, "bell_state.dd", false);
-    auto deserialized_bell_state = dd->deserialize<dd::vNode>("bell_state.dd", false);
-    EXPECT_EQ(bell_state, deserialized_bell_state);
+    serialize(bellState, "bell_state.dd", false);
+    auto deserializedBellState = dd->deserialize<dd::vNode>("bell_state.dd", false);
+    EXPECT_EQ(bellState, deserializedBellState);
 
-    serialize(bell_state, "bell_state_binary.dd", true);
-    deserialized_bell_state = dd->deserialize<dd::vNode>("bell_state_binary.dd", true);
-    EXPECT_EQ(bell_state, deserialized_bell_state);
+    serialize(bellState, "bell_state_binary.dd", true);
+    deserializedBellState = dd->deserialize<dd::vNode>("bell_state_binary.dd", true);
+    EXPECT_EQ(bellState, deserializedBellState);
 }
 
 TEST(DDPackageTest, BellMatrix) {
     auto dd = std::make_unique<dd::Package<>>(2);
 
-    auto h_gate  = dd->makeGateDD(dd::Hmat, 2, 1);
-    auto cx_gate = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
+    auto hGate  = dd->makeGateDD(dd::Hmat, 2, 1);
+    auto cxGate = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
 
-    auto bell_matrix = dd->multiply(cx_gate, h_gate);
+    auto bellMatrix = dd->multiply(cxGate, hGate);
 
-    ASSERT_EQ(dd->getValueByPath(bell_matrix, "00"), (dd::ComplexValue{dd::SQRT2_2, 0}));
-    ASSERT_EQ(dd->getValueByPath(bell_matrix, "02"), (dd::ComplexValue{0, 0}));
-    ASSERT_EQ(dd->getValueByPath(bell_matrix, "20"), (dd::ComplexValue{0, 0}));
-    ASSERT_EQ(dd->getValueByPath(bell_matrix, "22"), (dd::ComplexValue{dd::SQRT2_2, 0}));
+    ASSERT_EQ(dd->getValueByPath(bellMatrix, "00"), (dd::ComplexValue{dd::SQRT2_2, 0}));
+    ASSERT_EQ(dd->getValueByPath(bellMatrix, "02"), (dd::ComplexValue{0, 0}));
+    ASSERT_EQ(dd->getValueByPath(bellMatrix, "20"), (dd::ComplexValue{0, 0}));
+    ASSERT_EQ(dd->getValueByPath(bellMatrix, "22"), (dd::ComplexValue{dd::SQRT2_2, 0}));
 
-    ASSERT_EQ(dd->getValueByPath(bell_matrix, 0, 0), (dd::ComplexValue{dd::SQRT2_2, 0}));
-    ASSERT_EQ(dd->getValueByPath(bell_matrix, 1, 0), (dd::ComplexValue{0, 0}));
-    ASSERT_EQ(dd->getValueByPath(bell_matrix, 2, 0), (dd::ComplexValue{0, 0}));
-    ASSERT_EQ(dd->getValueByPath(bell_matrix, 3, 0), (dd::ComplexValue{dd::SQRT2_2, 0}));
+    ASSERT_EQ(dd->getValueByPath(bellMatrix, 0, 0), (dd::ComplexValue{dd::SQRT2_2, 0}));
+    ASSERT_EQ(dd->getValueByPath(bellMatrix, 1, 0), (dd::ComplexValue{0, 0}));
+    ASSERT_EQ(dd->getValueByPath(bellMatrix, 2, 0), (dd::ComplexValue{0, 0}));
+    ASSERT_EQ(dd->getValueByPath(bellMatrix, 3, 0), (dd::ComplexValue{dd::SQRT2_2, 0}));
 
-    ASSERT_EQ(dd->getValueByPath(bell_matrix, 0, 1), (dd::ComplexValue{0, 0}));
-    ASSERT_EQ(dd->getValueByPath(bell_matrix, 1, 1), (dd::ComplexValue{dd::SQRT2_2, 0}));
-    ASSERT_EQ(dd->getValueByPath(bell_matrix, 2, 1), (dd::ComplexValue{dd::SQRT2_2, 0}));
-    ASSERT_EQ(dd->getValueByPath(bell_matrix, 3, 1), (dd::ComplexValue{0, 0}));
+    ASSERT_EQ(dd->getValueByPath(bellMatrix, 0, 1), (dd::ComplexValue{0, 0}));
+    ASSERT_EQ(dd->getValueByPath(bellMatrix, 1, 1), (dd::ComplexValue{dd::SQRT2_2, 0}));
+    ASSERT_EQ(dd->getValueByPath(bellMatrix, 2, 1), (dd::ComplexValue{dd::SQRT2_2, 0}));
+    ASSERT_EQ(dd->getValueByPath(bellMatrix, 3, 1), (dd::ComplexValue{0, 0}));
 
-    ASSERT_EQ(dd->getValueByPath(bell_matrix, 0, 2), (dd::ComplexValue{dd::SQRT2_2, 0}));
-    ASSERT_EQ(dd->getValueByPath(bell_matrix, 1, 2), (dd::ComplexValue{0, 0}));
-    ASSERT_EQ(dd->getValueByPath(bell_matrix, 2, 2), (dd::ComplexValue{0, 0}));
-    ASSERT_EQ(dd->getValueByPath(bell_matrix, 3, 2), (dd::ComplexValue{-dd::SQRT2_2, 0}));
+    ASSERT_EQ(dd->getValueByPath(bellMatrix, 0, 2), (dd::ComplexValue{dd::SQRT2_2, 0}));
+    ASSERT_EQ(dd->getValueByPath(bellMatrix, 1, 2), (dd::ComplexValue{0, 0}));
+    ASSERT_EQ(dd->getValueByPath(bellMatrix, 2, 2), (dd::ComplexValue{0, 0}));
+    ASSERT_EQ(dd->getValueByPath(bellMatrix, 3, 2), (dd::ComplexValue{-dd::SQRT2_2, 0}));
 
-    ASSERT_EQ(dd->getValueByPath(bell_matrix, 0, 3), (dd::ComplexValue{0, 0}));
-    ASSERT_EQ(dd->getValueByPath(bell_matrix, 1, 3), (dd::ComplexValue{dd::SQRT2_2, 0}));
-    ASSERT_EQ(dd->getValueByPath(bell_matrix, 2, 3), (dd::ComplexValue{-dd::SQRT2_2, 0}));
-    ASSERT_EQ(dd->getValueByPath(bell_matrix, 3, 3), (dd::ComplexValue{0, 0}));
+    ASSERT_EQ(dd->getValueByPath(bellMatrix, 0, 3), (dd::ComplexValue{0, 0}));
+    ASSERT_EQ(dd->getValueByPath(bellMatrix, 1, 3), (dd::ComplexValue{dd::SQRT2_2, 0}));
+    ASSERT_EQ(dd->getValueByPath(bellMatrix, 2, 3), (dd::ComplexValue{-dd::SQRT2_2, 0}));
+    ASSERT_EQ(dd->getValueByPath(bellMatrix, 3, 3), (dd::ComplexValue{0, 0}));
 
-    auto goal_row_0  = dd::CVec{{dd::SQRT2_2, 0.}, {0., 0.}, {dd::SQRT2_2, 0.}, {0., 0.}};
-    auto goal_row_1  = dd::CVec{{0., 0.}, {dd::SQRT2_2, 0.}, {0., 0.}, {dd::SQRT2_2, 0.}};
-    auto goal_row_2  = dd::CVec{{0., 0.}, {dd::SQRT2_2, 0.}, {0., 0.}, {-dd::SQRT2_2, 0.}};
-    auto goal_row_3  = dd::CVec{{dd::SQRT2_2, 0.}, {0., 0.}, {-dd::SQRT2_2, 0.}, {0., 0.}};
-    auto goal_matrix = dd::CMat{goal_row_0, goal_row_1, goal_row_2, goal_row_3};
-    ASSERT_EQ(dd->getMatrix(bell_matrix), goal_matrix);
+    auto goalRow0  = dd::CVec{{dd::SQRT2_2, 0.}, {0., 0.}, {dd::SQRT2_2, 0.}, {0., 0.}};
+    auto goalRow1  = dd::CVec{{0., 0.}, {dd::SQRT2_2, 0.}, {0., 0.}, {dd::SQRT2_2, 0.}};
+    auto goalRow2  = dd::CVec{{0., 0.}, {dd::SQRT2_2, 0.}, {0., 0.}, {-dd::SQRT2_2, 0.}};
+    auto goalRow3  = dd::CVec{{dd::SQRT2_2, 0.}, {0., 0.}, {-dd::SQRT2_2, 0.}, {0., 0.}};
+    auto goalMatrix = dd::CMat{goalRow0, goalRow1, goalRow2, goalRow3};
+    ASSERT_EQ(dd->getMatrix(bellMatrix), goalMatrix);
 
-    export2Dot(bell_matrix, "bell_matrix_colored_labels.dot", true, true, false, false, false);
-    export2Dot(bell_matrix, "bell_matrix_colored_labels_classic.dot", true, true, true, false, false);
-    export2Dot(bell_matrix, "bell_matrix_mono_labels.dot", false, true, false, false, false);
-    export2Dot(bell_matrix, "bell_matrix_mono_labels_classic.dot", false, true, true, false, false);
-    export2Dot(bell_matrix, "bell_matrix_colored.dot", true, false, false, false, false);
-    export2Dot(bell_matrix, "bell_matrix_colored_classic.dot", true, false, true, false, false);
-    export2Dot(bell_matrix, "bell_matrix_mono.dot", false, false, false, false, false);
-    export2Dot(bell_matrix, "bell_matrix_mono_classic.dot", false, false, true, false, false);
-    export2Dot(bell_matrix, "bell_matrix_memory.dot", false, true, true, true, false);
+    export2Dot(bellMatrix, "bell_matrix_colored_labels.dot", true, true, false, false, false);
+    export2Dot(bellMatrix, "bell_matrix_colored_labels_classic.dot", true, true, true, false, false);
+    export2Dot(bellMatrix, "bell_matrix_mono_labels.dot", false, true, false, false, false);
+    export2Dot(bellMatrix, "bell_matrix_mono_labels_classic.dot", false, true, true, false, false);
+    export2Dot(bellMatrix, "bell_matrix_colored.dot", true, false, false, false, false);
+    export2Dot(bellMatrix, "bell_matrix_colored_classic.dot", true, false, true, false, false);
+    export2Dot(bellMatrix, "bell_matrix_mono.dot", false, false, false, false, false);
+    export2Dot(bellMatrix, "bell_matrix_mono_classic.dot", false, false, true, false, false);
+    export2Dot(bellMatrix, "bell_matrix_memory.dot", false, true, true, true, false);
 
     dd->statistics();
 }
@@ -277,30 +277,30 @@ TEST(DDPackageTest, BellMatrix) {
 TEST(DDPackageTest, MatrixSerializationTest) {
     auto dd = std::make_unique<dd::Package<>>(2);
 
-    auto h_gate  = dd->makeGateDD(dd::Hmat, 2, 1);
-    auto cx_gate = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
+    auto hGate  = dd->makeGateDD(dd::Hmat, 2, 1);
+    auto cxGate = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
 
-    auto bell_matrix = dd->multiply(cx_gate, h_gate);
+    auto bellMatrix = dd->multiply(cxGate, hGate);
 
-    serialize(bell_matrix, "bell_matrix.dd", false);
-    auto deserialized_bell_matrix = dd->deserialize<dd::mNode>("bell_matrix.dd", false);
-    EXPECT_EQ(bell_matrix, deserialized_bell_matrix);
+    serialize(bellMatrix, "bell_matrix.dd", false);
+    auto deserializedBellMatrix = dd->deserialize<dd::mNode>("bell_matrix.dd", false);
+    EXPECT_EQ(bellMatrix, deserializedBellMatrix);
 
-    serialize(bell_matrix, "bell_matrix_binary.dd", true);
-    deserialized_bell_matrix = dd->deserialize<dd::mNode>("bell_matrix_binary.dd", true);
-    EXPECT_EQ(bell_matrix, deserialized_bell_matrix);
+    serialize(bellMatrix, "bell_matrix_binary.dd", true);
+    deserializedBellMatrix = dd->deserialize<dd::mNode>("bell_matrix_binary.dd", true);
+    EXPECT_EQ(bellMatrix, deserializedBellMatrix);
 }
 
 TEST(DDPackageTest, SerializationErrors) {
     auto dd = std::make_unique<dd::Package<>>(2);
 
-    auto h_gate     = dd->makeGateDD(dd::Hmat, 2, 1);
-    auto cx_gate    = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
-    auto zero_state = dd->makeZeroState(2);
-    auto bell_state = dd->multiply(dd->multiply(cx_gate, h_gate), zero_state);
+    auto hGate     = dd->makeGateDD(dd::Hmat, 2, 1);
+    auto cxGate    = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
+    auto zeroState = dd->makeZeroState(2);
+    auto bellState = dd->multiply(dd->multiply(cxGate, hGate), zeroState);
 
     // test non-existing file
-    EXPECT_THROW(serialize(bell_state, "./path/that/does/not/exist/filename.dd"), std::invalid_argument);
+    EXPECT_THROW(serialize(bellState, "./path/that/does/not/exist/filename.dd"), std::invalid_argument);
     EXPECT_THROW(dd->deserialize<dd::vNode>("./path/that/does/not/exist/filename.dd", true), std::invalid_argument);
 
     // test wrong version number
@@ -312,9 +312,9 @@ TEST(DDPackageTest, SerializationErrors) {
 
     ss.str("");
     std::remove_const_t<decltype(dd::SERIALIZATION_VERSION)> version = 2;
-    ss.write(reinterpret_cast<const char*>(&version), sizeof(decltype(dd::SERIALIZATION_VERSION)));
+    ss.write(reinterpret_cast<const char*>(&version), sizeof(decltype(dd::SERIALIZATION_VERSION))); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
     EXPECT_THROW(dd->deserialize<dd::vNode>(ss, true), std::runtime_error);
-    ss.write(reinterpret_cast<const char*>(&version), sizeof(decltype(dd::SERIALIZATION_VERSION)));
+    ss.write(reinterpret_cast<const char*>(&version), sizeof(decltype(dd::SERIALIZATION_VERSION))); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
     EXPECT_THROW(dd->deserialize<dd::mNode>(ss, true), std::runtime_error);
 
     // test wrong format
@@ -340,25 +340,25 @@ TEST(DDPackageTest, SerializationErrors) {
 TEST(DDPackageTest, TestConsistency) {
     auto dd = std::make_unique<dd::Package<>>(2);
 
-    auto h_gate     = dd->makeGateDD(dd::Hmat, 2, 1);
-    auto cx_gate    = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
-    auto zero_state = dd->makeZeroState(2);
+    auto hGate     = dd->makeGateDD(dd::Hmat, 2, 1);
+    auto cxGate    = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
+    auto zeroState = dd->makeZeroState(2);
 
-    auto bell_matrix = dd->multiply(cx_gate, h_gate);
-    dd->incRef(bell_matrix);
-    auto local = dd->isLocallyConsistent(bell_matrix);
+    auto bellMatrix = dd->multiply(cxGate, hGate);
+    dd->incRef(bellMatrix);
+    auto local = dd->isLocallyConsistent(bellMatrix);
     EXPECT_TRUE(local);
-    auto global = dd->isGloballyConsistent(bell_matrix);
+    auto global = dd->isGloballyConsistent(bellMatrix);
     EXPECT_TRUE(global);
-    dd->debugnode(bell_matrix.p);
+    dd->debugnode(bellMatrix.p);
 
-    auto bell_state = dd->multiply(bell_matrix, zero_state);
-    dd->incRef(bell_state);
-    local = dd->isLocallyConsistent(bell_state);
+    auto bellState = dd->multiply(bellMatrix, zeroState);
+    dd->incRef(bellState);
+    local = dd->isLocallyConsistent(bellState);
     EXPECT_TRUE(local);
-    global = dd->isGloballyConsistent(bell_state);
+    global = dd->isGloballyConsistent(bellState);
     EXPECT_TRUE(global);
-    dd->debugnode(bell_state.p);
+    dd->debugnode(bellState.p);
 }
 
 TEST(DDPackageTest, ToffoliTable) {
@@ -415,7 +415,7 @@ TEST(DDPackageTest, Identity) {
 
     auto id3 = dd->makeIdent(3);
     EXPECT_EQ(dd->makeIdent(0, 2), id3);
-    auto& table = dd->getIdentityTable();
+    const auto& table = dd->getIdentityTable();
     EXPECT_NE(table[2].p, nullptr);
 
     auto id2 = dd->makeIdent(0, 1); // should be found in IdTable
@@ -432,127 +432,127 @@ TEST(DDPackageTest, Identity) {
 TEST(DDPackageTest, TestLocalInconsistency) {
     auto dd = std::make_unique<dd::Package<>>(3);
 
-    auto h_gate     = dd->makeGateDD(dd::Hmat, 2, 0);
-    auto cx_gate    = dd->makeGateDD(dd::Xmat, 2, 0_pc, 1);
-    auto zero_state = dd->makeZeroState(2);
+    auto hGate     = dd->makeGateDD(dd::Hmat, 2, 0);
+    auto cxGate    = dd->makeGateDD(dd::Xmat, 2, 0_pc, 1);
+    auto zeroState = dd->makeZeroState(2);
 
-    auto bell_state = dd->multiply(dd->multiply(cx_gate, h_gate), zero_state);
-    auto local      = dd->isLocallyConsistent(bell_state);
+    auto bellState = dd->multiply(dd->multiply(cxGate, hGate), zeroState);
+    auto local      = dd->isLocallyConsistent(bellState);
     EXPECT_FALSE(local);
-    bell_state.p->ref = 1;
-    local             = dd->isLocallyConsistent(bell_state);
+    bellState.p->ref = 1;
+    local             = dd->isLocallyConsistent(bellState);
     EXPECT_FALSE(local);
-    bell_state.p->ref = 0;
-    dd->incRef(bell_state);
+    bellState.p->ref = 0;
+    dd->incRef(bellState);
 
-    bell_state.p->v = 2;
-    local           = dd->isLocallyConsistent(bell_state);
+    bellState.p->v = 2;
+    local           = dd->isLocallyConsistent(bellState);
     EXPECT_FALSE(local);
-    bell_state.p->v = 1;
+    bellState.p->v = 1;
 
-    bell_state.p->e[0].w.r->refCount = 0;
-    local                            = dd->isLocallyConsistent(bell_state);
+    bellState.p->e[0].w.r->refCount = 0;
+    local                            = dd->isLocallyConsistent(bellState);
     EXPECT_FALSE(local);
-    bell_state.p->e[0].w.r->refCount = 1;
+    bellState.p->e[0].w.r->refCount = 1;
 }
 
 TEST(DDPackageTest, Ancillaries) {
     auto dd          = std::make_unique<dd::Package<>>(4);
-    auto h_gate      = dd->makeGateDD(dd::Hmat, 2, 0);
-    auto cx_gate     = dd->makeGateDD(dd::Xmat, 2, 0_pc, 1);
-    auto bell_matrix = dd->multiply(cx_gate, h_gate);
+    auto hGate      = dd->makeGateDD(dd::Hmat, 2, 0);
+    auto cxGate     = dd->makeGateDD(dd::Xmat, 2, 0_pc, 1);
+    auto bellMatrix = dd->multiply(cxGate, hGate);
 
-    dd->incRef(bell_matrix);
-    auto reduced_bell_matrix = dd->reduceAncillae(bell_matrix, {false, false, false, false});
-    EXPECT_EQ(bell_matrix, reduced_bell_matrix);
-    dd->incRef(bell_matrix);
-    reduced_bell_matrix = dd->reduceAncillae(bell_matrix, {false, false, true, true});
-    EXPECT_EQ(bell_matrix, reduced_bell_matrix);
+    dd->incRef(bellMatrix);
+    auto reducedBellMatrix = dd->reduceAncillae(bellMatrix, {false, false, false, false});
+    EXPECT_EQ(bellMatrix, reducedBellMatrix);
+    dd->incRef(bellMatrix);
+    reducedBellMatrix = dd->reduceAncillae(bellMatrix, {false, false, true, true});
+    EXPECT_EQ(bellMatrix, reducedBellMatrix);
 
-    auto extended_bell_matrix = dd->extend(bell_matrix, 2);
-    dd->incRef(extended_bell_matrix);
-    reduced_bell_matrix = dd->reduceAncillae(extended_bell_matrix, {false, false, true, true});
-    EXPECT_TRUE(reduced_bell_matrix.p->e[1].isZeroTerminal());
-    EXPECT_TRUE(reduced_bell_matrix.p->e[2].isZeroTerminal());
-    EXPECT_TRUE(reduced_bell_matrix.p->e[3].isZeroTerminal());
+    auto extendedBellMatrix = dd->extend(bellMatrix, 2);
+    dd->incRef(extendedBellMatrix);
+    reducedBellMatrix = dd->reduceAncillae(extendedBellMatrix, {false, false, true, true});
+    EXPECT_TRUE(reducedBellMatrix.p->e[1].isZeroTerminal());
+    EXPECT_TRUE(reducedBellMatrix.p->e[2].isZeroTerminal());
+    EXPECT_TRUE(reducedBellMatrix.p->e[3].isZeroTerminal());
 
-    EXPECT_EQ(reduced_bell_matrix.p->e[0].p->e[0].p, bell_matrix.p);
-    EXPECT_TRUE(reduced_bell_matrix.p->e[0].p->e[1].isZeroTerminal());
-    EXPECT_TRUE(reduced_bell_matrix.p->e[0].p->e[2].isZeroTerminal());
-    EXPECT_TRUE(reduced_bell_matrix.p->e[0].p->e[3].isZeroTerminal());
+    EXPECT_EQ(reducedBellMatrix.p->e[0].p->e[0].p, bellMatrix.p);
+    EXPECT_TRUE(reducedBellMatrix.p->e[0].p->e[1].isZeroTerminal());
+    EXPECT_TRUE(reducedBellMatrix.p->e[0].p->e[2].isZeroTerminal());
+    EXPECT_TRUE(reducedBellMatrix.p->e[0].p->e[3].isZeroTerminal());
 
-    dd->incRef(extended_bell_matrix);
-    reduced_bell_matrix = dd->reduceAncillae(extended_bell_matrix, {false, false, true, true}, false);
-    EXPECT_TRUE(reduced_bell_matrix.p->e[1].isZeroTerminal());
-    EXPECT_TRUE(reduced_bell_matrix.p->e[2].isZeroTerminal());
-    EXPECT_TRUE(reduced_bell_matrix.p->e[3].isZeroTerminal());
+    dd->incRef(extendedBellMatrix);
+    reducedBellMatrix = dd->reduceAncillae(extendedBellMatrix, {false, false, true, true}, false);
+    EXPECT_TRUE(reducedBellMatrix.p->e[1].isZeroTerminal());
+    EXPECT_TRUE(reducedBellMatrix.p->e[2].isZeroTerminal());
+    EXPECT_TRUE(reducedBellMatrix.p->e[3].isZeroTerminal());
 
-    EXPECT_EQ(reduced_bell_matrix.p->e[0].p->e[0].p, bell_matrix.p);
-    EXPECT_TRUE(reduced_bell_matrix.p->e[0].p->e[1].isZeroTerminal());
-    EXPECT_TRUE(reduced_bell_matrix.p->e[0].p->e[2].isZeroTerminal());
-    EXPECT_TRUE(reduced_bell_matrix.p->e[0].p->e[3].isZeroTerminal());
+    EXPECT_EQ(reducedBellMatrix.p->e[0].p->e[0].p, bellMatrix.p);
+    EXPECT_TRUE(reducedBellMatrix.p->e[0].p->e[1].isZeroTerminal());
+    EXPECT_TRUE(reducedBellMatrix.p->e[0].p->e[2].isZeroTerminal());
+    EXPECT_TRUE(reducedBellMatrix.p->e[0].p->e[3].isZeroTerminal());
 }
 
 TEST(DDPackageTest, GarbageVector) {
     auto dd         = std::make_unique<dd::Package<>>(4);
-    auto h_gate     = dd->makeGateDD(dd::Hmat, 2, 0);
-    auto cx_gate    = dd->makeGateDD(dd::Xmat, 2, 0_pc, 1);
-    auto zero_state = dd->makeZeroState(2);
-    auto bell_state = dd->multiply(dd->multiply(cx_gate, h_gate), zero_state);
-    dd->printVector(bell_state);
+    auto hGate     = dd->makeGateDD(dd::Hmat, 2, 0);
+    auto cxGate    = dd->makeGateDD(dd::Xmat, 2, 0_pc, 1);
+    auto zeroState = dd->makeZeroState(2);
+    auto bellState = dd->multiply(dd->multiply(cxGate, hGate), zeroState);
+    dd->printVector(bellState);
 
-    dd->incRef(bell_state);
-    auto reduced_bell_state = dd->reduceGarbage(bell_state, {false, false, false, false});
-    EXPECT_EQ(bell_state, reduced_bell_state);
-    dd->incRef(bell_state);
-    reduced_bell_state = dd->reduceGarbage(bell_state, {false, false, true, false});
-    EXPECT_EQ(bell_state, reduced_bell_state);
+    dd->incRef(bellState);
+    auto reducedBellState = dd->reduceGarbage(bellState, {false, false, false, false});
+    EXPECT_EQ(bellState, reducedBellState);
+    dd->incRef(bellState);
+    reducedBellState = dd->reduceGarbage(bellState, {false, false, true, false});
+    EXPECT_EQ(bellState, reducedBellState);
 
-    dd->incRef(bell_state);
-    reduced_bell_state = dd->reduceGarbage(bell_state, {false, true, false, false});
-    auto vec           = dd->getVector(reduced_bell_state);
-    dd->printVector(reduced_bell_state);
+    dd->incRef(bellState);
+    reducedBellState = dd->reduceGarbage(bellState, {false, true, false, false});
+    auto vec           = dd->getVector(reducedBellState);
+    dd->printVector(reducedBellState);
     EXPECT_EQ(vec[2], static_cast<std::complex<dd::fp>>(dd::complex_zero));
     EXPECT_EQ(vec[3], static_cast<std::complex<dd::fp>>(dd::complex_zero));
 
-    dd->incRef(bell_state);
-    reduced_bell_state = dd->reduceGarbage(bell_state, {true, false, false, false});
-    dd->printVector(reduced_bell_state);
-    vec = dd->getVector(reduced_bell_state);
+    dd->incRef(bellState);
+    reducedBellState = dd->reduceGarbage(bellState, {true, false, false, false});
+    dd->printVector(reducedBellState);
+    vec = dd->getVector(reducedBellState);
     EXPECT_EQ(vec[1], static_cast<std::complex<dd::fp>>(dd::complex_zero));
     EXPECT_EQ(vec[3], static_cast<std::complex<dd::fp>>(dd::complex_zero));
 }
 
 TEST(DDPackageTest, GarbageMatrix) {
     auto dd          = std::make_unique<dd::Package<>>(4);
-    auto h_gate      = dd->makeGateDD(dd::Hmat, 2, 0);
-    auto cx_gate     = dd->makeGateDD(dd::Xmat, 2, 0_pc, 1);
-    auto bell_matrix = dd->multiply(cx_gate, h_gate);
+    auto hGate      = dd->makeGateDD(dd::Hmat, 2, 0);
+    auto cxGate     = dd->makeGateDD(dd::Xmat, 2, 0_pc, 1);
+    auto bellMatrix = dd->multiply(cxGate, hGate);
 
-    dd->incRef(bell_matrix);
-    auto reduced_bell_matrix = dd->reduceGarbage(bell_matrix, {false, false, false, false});
-    EXPECT_EQ(bell_matrix, reduced_bell_matrix);
-    dd->incRef(bell_matrix);
-    reduced_bell_matrix = dd->reduceGarbage(bell_matrix, {false, false, true, false});
-    EXPECT_EQ(bell_matrix, reduced_bell_matrix);
+    dd->incRef(bellMatrix);
+    auto reducedBellMatrix = dd->reduceGarbage(bellMatrix, {false, false, false, false});
+    EXPECT_EQ(bellMatrix, reducedBellMatrix);
+    dd->incRef(bellMatrix);
+    reducedBellMatrix = dd->reduceGarbage(bellMatrix, {false, false, true, false});
+    EXPECT_EQ(bellMatrix, reducedBellMatrix);
 
-    dd->incRef(bell_matrix);
-    reduced_bell_matrix = dd->reduceGarbage(bell_matrix, {false, true, false, false});
-    auto mat            = dd->getMatrix(reduced_bell_matrix);
+    dd->incRef(bellMatrix);
+    reducedBellMatrix = dd->reduceGarbage(bellMatrix, {false, true, false, false});
+    auto mat            = dd->getMatrix(reducedBellMatrix);
     auto zero           = dd::CVec{{0., 0.}, {0., 0.}, {0., 0.}, {0., 0.}};
     EXPECT_EQ(mat[2], zero);
     EXPECT_EQ(mat[3], zero);
 
-    dd->incRef(bell_matrix);
-    reduced_bell_matrix = dd->reduceGarbage(bell_matrix, {true, false, false, false});
-    mat                 = dd->getMatrix(reduced_bell_matrix);
+    dd->incRef(bellMatrix);
+    reducedBellMatrix = dd->reduceGarbage(bellMatrix, {true, false, false, false});
+    mat                 = dd->getMatrix(reducedBellMatrix);
     EXPECT_EQ(mat[1], zero);
     EXPECT_EQ(mat[3], zero);
 
-    dd->incRef(bell_matrix);
-    reduced_bell_matrix = dd->reduceGarbage(bell_matrix, {false, true, false, false}, false);
-    EXPECT_TRUE(reduced_bell_matrix.p->e[1].isZeroTerminal());
-    EXPECT_TRUE(reduced_bell_matrix.p->e[3].isZeroTerminal());
+    dd->incRef(bellMatrix);
+    reducedBellMatrix = dd->reduceGarbage(bellMatrix, {false, true, false, false}, false);
+    EXPECT_TRUE(reducedBellMatrix.p->e[1].isZeroTerminal());
+    EXPECT_TRUE(reducedBellMatrix.p->e[3].isZeroTerminal());
 }
 
 TEST(DDPackageTest, InvalidMakeBasisStateAndGate) {
@@ -576,18 +576,18 @@ TEST(DDPackageTest, PackageReset) {
     auto dd = std::make_unique<dd::Package<>>(1);
 
     // one node in unique table of variable 0
-    auto        i_gate = dd->makeIdent(1);
+    auto        iGate = dd->makeIdent(1);
     const auto& unique = dd->mUniqueTable.getTables();
     const auto& table  = unique[0];
-    auto        ihash  = dd->mUniqueTable.hash(i_gate.p);
+    auto        ihash  = decltype(dd->mUniqueTable)::hash(iGate.p);
     const auto* node   = table[ihash];
-    std::cout << ihash << ": " << reinterpret_cast<uintptr_t>(i_gate.p) << std::endl;
+    std::cout << ihash << ": " << reinterpret_cast<uintptr_t>(iGate.p) << std::endl; // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
     // node should be the first in this unique table bucket
-    EXPECT_EQ(node, i_gate.p);
+    EXPECT_EQ(node, iGate.p);
     dd->reset();
     // after clearing the tables, they should be empty
     EXPECT_EQ(table[ihash], nullptr);
-    i_gate            = dd->makeIdent(1);
+    iGate            = dd->makeIdent(1);
     const auto* node2 = table[ihash];
     // after recreating the DD, it should receive the same node
     EXPECT_EQ(node2, node);
@@ -632,7 +632,7 @@ TEST(DDPackageTest, UniqueTableAllocation) {
     }
 
     // trigger new allocation
-    [[maybe_unused]] auto node = dd->vUniqueTable.getNode();
+    [[maybe_unused]] auto *node = dd->vUniqueTable.getNode();
     EXPECT_EQ(dd->vUniqueTable.getAllocations(), (1. + dd->vUniqueTable.getGrowthFactor()) * allocs);
 
     // clearing the unique table should reduce the allocated size to the original size
@@ -714,8 +714,8 @@ TEST(DDPackageTest, SpecialCaseTerminal) {
 
 TEST(DDPackageTest, KroneckerProduct) {
     auto dd        = std::make_unique<dd::Package<>>(2);
-    auto X         = dd->makeGateDD(dd::Xmat, 1, 0);
-    auto kronecker = dd->kronecker(X, X);
+    auto x         = dd->makeGateDD(dd::Xmat, 1, 0);
+    auto kronecker = dd->kronecker(x, x);
     EXPECT_EQ(kronecker.p->v, 1);
     EXPECT_EQ(kronecker.p->e[0], dd::mEdge::zero);
     EXPECT_EQ(kronecker.p->e[0], kronecker.p->e[3]);
@@ -726,7 +726,7 @@ TEST(DDPackageTest, KroneckerProduct) {
     EXPECT_EQ(kronecker.p->e[1].p->e[1], dd::mEdge::one);
     EXPECT_EQ(kronecker.p->e[1].p->e[1], kronecker.p->e[1].p->e[2]);
 
-    auto kronecker2 = dd->kronecker(X, X);
+    auto kronecker2 = dd->kronecker(x, x);
     EXPECT_EQ(kronecker, kronecker2);
 }
 
@@ -800,7 +800,7 @@ TEST(DDPackageTest, DestructiveMeasurementAll) {
     auto plusState  = dd->multiply(plusMatrix, zeroState);
     dd->incRef(plusState);
 
-    std::mt19937_64 mt{0};
+    std::mt19937_64 mt{0}; // NOLINT(ms
 
     const dd::CVec vBefore = dd->getVector(plusState);
 
@@ -825,7 +825,7 @@ TEST(DDPackageTest, DestructiveMeasurementOne) {
     auto plusState  = dd->multiply(plusMatrix, zeroState);
     dd->incRef(plusState);
 
-    std::mt19937_64 mt{0};
+    std::mt19937_64 mt{0}; // NOLINT(cert-msc51-cpp)
 
     const char     m      = dd->measureOneCollapsing(plusState, 0, true, mt);
     const dd::CVec vAfter = dd->getVector(plusState);
@@ -846,7 +846,7 @@ TEST(DDPackageTest, DestructiveMeasurementOneArbitraryNormalization) {
     auto plusState  = dd->multiply(plusMatrix, zeroState);
     dd->incRef(plusState);
 
-    std::mt19937_64 mt{0};
+    std::mt19937_64 mt{0}; // NOLINT(cert-msc51-cpp)
 
     const char     m      = dd->measureOneCollapsing(plusState, 0, false, mt);
     const dd::CVec vAfter = dd->getVector(plusState);
@@ -944,21 +944,28 @@ TEST(DDPackageTest, ExportConditionalFormat) {
 }
 
 TEST(DDPackageTest, BasicNumericInstabilityTest) {
-    using limits = std::numeric_limits<dd::fp>;
+    const dd::fp zero = 0.0;
+    const dd::fp half = 0.5;
+    const dd::fp one = 1.0;
+    const dd::fp two = 2.0;
 
-    std::cout << std::setprecision(limits::max_digits10);
+    std::cout << std::setprecision(std::numeric_limits<dd::fp>::max_digits10);
 
-    std::cout << "The 1/sqrt(2) constant used in this package is " << dd::SQRT2_2 << ", which is the closest floating point value to the actual value of 1/sqrt(2)." << std::endl;
-    std::cout << "Computing std::sqrt(0.5) actually computes this value, i.e. " << std::sqrt(dd::fp(0.5)) << std::endl;
-    EXPECT_EQ(dd::SQRT2_2, std::sqrt(dd::fp(0.5)));
-    std::cout << "However, computing 1/std::sqrt(2.) leads to " << dd::fp(1.0) / std::sqrt(dd::fp(2.)) << ", which differs by 1 ULP from std::sqrt(0.5)" << std::endl;
-    EXPECT_EQ(dd::fp(1.0) / std::sqrt(dd::fp(2.)), std::nextafter(std::sqrt(dd::fp(0.5)), 0.));
-    std::cout << "In the same fashion, computing std::sqrt(2.) leads to " << std::sqrt(dd::fp(2.)) << ", while computing 1/std::sqrt(0.5) leads to " << dd::fp(1.) / std::sqrt(dd::fp(0.5)) << ", which differ by exactly 1 ULP" << std::endl;
-    EXPECT_EQ(std::sqrt(dd::fp(2.)), std::nextafter(dd::fp(1.) / std::sqrt(dd::fp(0.5)), 2.));
-    std::cout << "Another inaccuracy occurs when computing 1/sqrt(2) * 1/sqrt(2), which should equal to 0.5 but is off by 1 ULP: " << std::sqrt(dd::fp(0.5)) * std::sqrt(dd::fp(0.5)) << std::endl;
-    EXPECT_EQ(std::sqrt(dd::fp(0.5)) * std::sqrt(dd::fp(0.5)), std::nextafter(0.5, 1.));
-    std::cout << "This inaccuracy even persists when computing std::sqrt(0.5) * std::sqrt(0.5): " << std::sqrt(dd::fp(0.5)) * std::sqrt(dd::fp(0.5)) << std::endl;
-    EXPECT_EQ(std::sqrt(dd::fp(0.5)) * std::sqrt(dd::fp(0.5)), std::nextafter(dd::fp(0.5), 1.));
+    std::cout << "The 1/sqrt(2) constant used in this package is " << dd::SQRT2_2 << ", which is the closest floating point value to the actual value of 1/sqrt(2).\n";
+    std::cout << "Computing std::sqrt(0.5) actually computes this value, i.e. " << std::sqrt(half) << "\n";
+    EXPECT_EQ(dd::SQRT2_2, std::sqrt(half));
+
+    std::cout << "However, computing 1/std::sqrt(2.) leads to " << one / std::sqrt(two) << ", which differs by 1 ULP from std::sqrt(0.5)\n";
+    EXPECT_EQ(one / std::sqrt(two), std::nextafter(std::sqrt(half), zero));
+
+    std::cout << "In the same fashion, computing std::sqrt(2.) leads to " << std::sqrt(two) << ", while computing 1/std::sqrt(0.5) leads to " << one / std::sqrt(half) << ", which differ by exactly 1 ULP\n";
+    EXPECT_EQ(std::sqrt(two), std::nextafter(one / std::sqrt(half), two));
+
+    std::cout << "Another inaccuracy occurs when computing 1/sqrt(2) * 1/sqrt(2), which should equal to 0.5 but is off by 1 ULP: " << std::sqrt(half) * std::sqrt(half) << "\n";
+    EXPECT_EQ(std::sqrt(half) * std::sqrt(half), std::nextafter(half, one));
+
+    std::cout << "This inaccuracy even persists when computing std::sqrt(0.5) * std::sqrt(0.5): " << std::sqrt(half) * std::sqrt(half) << "\n";
+    EXPECT_EQ(std::sqrt(half) * std::sqrt(half), std::nextafter(half, one));
 
     //    std::cout << "Interestingly, calculating powers of dd::SQRT2_2 can be conducted very precisely, i.e., with an error of only 1 ULP." << std::endl;
     //    dd::fp      accumulator = dd::SQRT2_2 * dd::SQRT2_2;
@@ -1019,17 +1026,17 @@ TEST(DDPackageTest, NormalizationNumericStabilityTest) {
 TEST(DDPackageTest, FidelityOfMeasurementOutcomes) {
     auto dd = std::make_unique<dd::Package<>>(3);
 
-    auto h_gate     = dd->makeGateDD(dd::Hmat, 3, 2);
-    auto cx_gate1   = dd->makeGateDD(dd::Xmat, 3, 2_pc, 1);
-    auto cx_gate2   = dd->makeGateDD(dd::Xmat, 3, 1_pc, 0);
-    auto zero_state = dd->makeZeroState(3);
+    auto hGate     = dd->makeGateDD(dd::Hmat, 3, 2);
+    auto cxGate1   = dd->makeGateDD(dd::Xmat, 3, 2_pc, 1);
+    auto cxGate2   = dd->makeGateDD(dd::Xmat, 3, 1_pc, 0);
+    auto zeroState = dd->makeZeroState(3);
 
-    auto ghz_state = dd->multiply(cx_gate2, dd->multiply(cx_gate1, dd->multiply(h_gate, zero_state)));
+    auto ghzState = dd->multiply(cxGate2, dd->multiply(cxGate1, dd->multiply(hGate, zeroState)));
 
     dd::ProbabilityVector probs{};
     probs[0]      = 0.5;
     probs[7]      = 0.5;
-    auto fidelity = dd->fidelityOfMeasurementOutcomes(ghz_state, probs);
+    auto fidelity = dd->fidelityOfMeasurementOutcomes(ghzState, probs);
     EXPECT_NEAR(fidelity, 1.0, dd::ComplexTable<>::tolerance());
 }
 
@@ -1124,8 +1131,8 @@ TEST(DDPackageTest, dNodeMultiply) {
 
     const auto stateDensityMatrix = dd->getDensityMatrix(state);
 
-    for (auto& stateVector: stateDensityMatrix) {
-        for (auto& cValue: stateVector) {
+    for (const auto& stateVector: stateDensityMatrix) {
+        for (const auto& cValue: stateVector) {
             std::cout << "r:" << cValue.real() << " i:" << cValue.imag();
         }
         std::cout << std::endl;
@@ -1145,7 +1152,7 @@ TEST(DDPackageTest, dNodeMultiply) {
 
     const auto probVector = dd->getProbVectorFromDensityMatrix(state, 0.001);
     double     tolerance  = 1e-10;
-    for (auto& prob: probVector) {
+    for (const auto& prob: probVector) {
         std::cout << prob.first << ": " << prob.second << std::endl;
         EXPECT_NEAR(prob.second, 0.125, tolerance);
     }
@@ -1153,16 +1160,16 @@ TEST(DDPackageTest, dNodeMultiply) {
 
 TEST(DDPackageTest, dNodeMultiply2) {
     //Multiply dNode with mNode (MxMxM)
-    dd::Qubit nr_qubits = 3;
-    auto      dd        = std::make_unique<DensityMatrixPackageTest>(nr_qubits);
+    const dd::Qubit nrQubits = 3;
+    auto      dd        = std::make_unique<DensityMatrixPackageTest>(nrQubits);
     // Make zero density matrix
     auto state = dd->makeZeroDensityOperator(dd->qubits());
     dd->incRef(state);
     std::vector<dd::mEdge> operations = {};
-    operations.emplace_back(dd->makeGateDD(dd::Hmat, nr_qubits, 0));
-    operations.emplace_back(dd->makeGateDD(dd::Hmat, nr_qubits, 1));
-    operations.emplace_back(dd->makeGateDD(dd::Hmat, nr_qubits, 2));
-    operations.emplace_back(dd->makeGateDD(dd::Zmat, nr_qubits, 2));
+    operations.emplace_back(dd->makeGateDD(dd::Hmat, nrQubits, 0));
+    operations.emplace_back(dd->makeGateDD(dd::Hmat, nrQubits, 1));
+    operations.emplace_back(dd->makeGateDD(dd::Hmat, nrQubits, 2));
+    operations.emplace_back(dd->makeGateDD(dd::Zmat, nrQubits, 2));
 
     for (auto& op: operations) {
         dd->applyOperationToDensity(state, op, true);
@@ -1171,8 +1178,8 @@ TEST(DDPackageTest, dNodeMultiply2) {
 
     const auto stateDensityMatrix = dd->getDensityMatrix(state);
 
-    for (int i = 0; i < (1 << nr_qubits); i++) {
-        for (int j = 0; j < (1 << nr_qubits); j++) {
+    for (int i = 0; i < (1 << nrQubits); i++) {
+        for (int j = 0; j < (1 << nrQubits); j++) {
             EXPECT_TRUE(std::abs(stateDensityMatrix[i][j].imag()) == 0);
             if ((i < 4 && j < 4) || (i >= 4 && j >= 4)) {
                 EXPECT_TRUE(stateDensityMatrix[i][j].real() > 0);
@@ -1192,19 +1199,19 @@ TEST(DDPackageTest, dNodeMultiply2) {
 
 TEST(DDPackageTest, dNodeMulCache1) {
     // Make caching test with dNodes
-    dd::Qubit nr_qubits = 1;
-    auto      dd        = std::make_unique<DensityMatrixPackageTest>(nr_qubits);
+    const dd::Qubit nrQubits = 1;
+    auto      dd        = std::make_unique<DensityMatrixPackageTest>(nrQubits);
     // Make zero density matrix
     auto state = dd->makeZeroDensityOperator(dd->qubits());
     dd->incRef(state);
 
     std::vector<dd::mEdge> operations = {};
-    operations.emplace_back(dd->makeGateDD(dd::Hmat, nr_qubits, 0));
+    operations.emplace_back(dd->makeGateDD(dd::Hmat, nrQubits, 0));
 
     for (auto& op: operations) {
         auto tmp0 = dd->conjugateTranspose(op);
-        auto tmp1 = dd->multiply(state, reinterpret_cast<dd::dEdge&>(tmp0), 0, false);
-        auto tmp2 = dd->multiply(reinterpret_cast<dd::dEdge&>(op), tmp1, 0, false);
+        auto tmp1 = dd->multiply(state, reinterpret_cast<dd::dEdge&>(tmp0), 0, false); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+        auto tmp2 = dd->multiply(reinterpret_cast<dd::dEdge&>(op), tmp1, 0, false); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
         dd->incRef(tmp2);
         state = tmp2;
     }
@@ -1218,49 +1225,49 @@ TEST(DDPackageTest, dNodeMulCache1) {
 
         auto xCopy = state1;
         xCopy.w    = dd::Complex::one;
-        auto yCopy = reinterpret_cast<dd::dEdge&>(tmp0);
+        auto yCopy = reinterpret_cast<dd::dEdge&>(tmp0); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
         yCopy.w    = dd::Complex::one;
 
-        auto _tmp1 = computeTable.lookup(xCopy, yCopy, false);
-        auto tmp1  = dd->multiply(state1, reinterpret_cast<dd::dEdge&>(tmp0), 0, false);
-        EXPECT_TRUE(_tmp1.p != nullptr && tmp1.p == _tmp1.p);
+        auto tmptmp1 = computeTable.lookup(xCopy, yCopy, false);
+        auto tmp1  = dd->multiply(state1, reinterpret_cast<dd::dEdge&>(tmp0), 0, false); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+        EXPECT_TRUE(tmp1.p != nullptr && tmp1.p == tmp1.p);
 
-        auto xCopy1 = reinterpret_cast<dd::dEdge&>(op);
+        auto xCopy1 = reinterpret_cast<dd::dEdge&>(op); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
         xCopy1.w    = dd::Complex::one;
         auto yCopy1 = tmp1;
         yCopy1.w    = dd::Complex::one;
 
-        auto _tmp2 = computeTable.lookup(xCopy1, yCopy1, true);
-        auto tmp2  = dd->multiply(reinterpret_cast<dd::dEdge&>(op), tmp1, 0, true);
-        EXPECT_EQ(_tmp2.p, nullptr);
+        auto tmptmp2 = computeTable.lookup(xCopy1, yCopy1, true);
+        auto tmp2  = dd->multiply(reinterpret_cast<dd::dEdge&>(op), tmp1, 0, true); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+        EXPECT_EQ(tmptmp2.p, nullptr);
 
-        auto _tmp3 = computeTable.lookup(xCopy1, yCopy1, true);
-        EXPECT_TRUE(_tmp3.p != nullptr && tmp2.p == _tmp3.p);
+        auto tmptmp3 = computeTable.lookup(xCopy1, yCopy1, true);
+        EXPECT_TRUE(tmptmp3.p != nullptr && tmp2.p == tmptmp3.p);
 
         computeTable.clear();
-        auto _tmp4 = computeTable.lookup(xCopy1, yCopy1, true);
-        EXPECT_EQ(_tmp4.p, nullptr);
+        auto tmptmp4 = computeTable.lookup(xCopy1, yCopy1, true);
+        EXPECT_EQ(tmptmp4.p, nullptr);
     }
 }
 
 TEST(DDPackageTest, dNoiseCache) {
     // Test the flags for dnode, vnode and mnodes
-    dd::Qubit nr_qubits = 1;
-    auto      dd        = std::make_unique<dd::Package<>>(nr_qubits);
+    const dd::Qubit nrQubits = 1;
+    auto      dd        = std::make_unique<dd::Package<>>(nrQubits);
     // Make zero density matrix
     auto state = dd->makeZeroDensityOperator(dd->qubits());
     dd->incRef(state);
 
     std::vector<dd::mEdge> operations = {};
-    operations.emplace_back(dd->makeGateDD(dd::Xmat, nr_qubits, 0));
+    operations.emplace_back(dd->makeGateDD(dd::Xmat, nrQubits, 0));
 
     std::vector<dd::Qubit> target = {0};
 
     auto noiseLookUpResult = dd->densityNoise.lookup(state, target);
     EXPECT_EQ(noiseLookUpResult.p, nullptr);
     auto tmp0 = dd->conjugateTranspose(operations[0]);
-    auto tmp1 = dd->multiply(state, reinterpret_cast<dd::dEdge&>(tmp0), 0, false);
-    auto tmp2 = dd->multiply(reinterpret_cast<dd::dEdge&>(operations[0]), tmp1, 0, true);
+    auto tmp1 = dd->multiply(state, reinterpret_cast<dd::dEdge&>(tmp0), 0, false); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto tmp2 = dd->multiply(reinterpret_cast<dd::dEdge&>(operations[0]), tmp1, 0, true); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
     dd->incRef(tmp2);
     auto state1 = tmp2;
     dd->densityNoise.insert(state, state1, target);
@@ -1274,47 +1281,47 @@ TEST(DDPackageTest, dNoiseCache) {
 }
 
 TEST(DDPackageTest, calCulpDistance) {
-    dd::Qubit nr_qubits = 1;
-    auto      dd        = std::make_unique<dd::Package<>>(nr_qubits);
+    dd::Qubit nrQubits = 1;
+    auto      dd        = std::make_unique<dd::Package<>>(nrQubits);
     auto      tmp0      = dd::ulpDistance(1 + 1e-12, 1);
     auto      tmp1      = dd::ulpDistance(1, 1);
     EXPECT_TRUE(tmp0 > 0);
     EXPECT_EQ(tmp1, 0);
 }
 
-struct stochPackageConfig: public dd::DDPackageConfig {
+struct StochPackageConfig: public dd::DDPackageConfig {
     static constexpr std::size_t STOCHASTIC_CACHE_OPS = 36;
 };
 
-using stochPackage = dd::Package<stochPackageConfig::UT_VEC_NBUCKET,
-                                 stochPackageConfig::UT_VEC_INITIAL_ALLOCATION_SIZE,
-                                 stochPackageConfig::UT_MAT_NBUCKET,
-                                 stochPackageConfig::UT_MAT_INITIAL_ALLOCATION_SIZE,
-                                 stochPackageConfig::CT_VEC_ADD_NBUCKET,
-                                 stochPackageConfig::CT_MAT_ADD_NBUCKET,
-                                 stochPackageConfig::CT_MAT_TRANS_NBUCKET,
-                                 stochPackageConfig::CT_MAT_CONJ_TRANS_NBUCKET,
-                                 stochPackageConfig::CT_MAT_VEC_MULT_NBUCKET,
-                                 stochPackageConfig::CT_MAT_MAT_MULT_NBUCKET,
-                                 stochPackageConfig::CT_VEC_KRON_NBUCKET,
-                                 stochPackageConfig::CT_MAT_KRON_NBUCKET,
-                                 stochPackageConfig::CT_VEC_INNER_PROD_NBUCKET,
-                                 stochPackageConfig::CT_DM_NOISE_NBUCKET,
-                                 stochPackageConfig::UT_DM_NBUCKET,
-                                 stochPackageConfig::UT_DM_INITIAL_ALLOCATION_SIZE,
-                                 stochPackageConfig::CT_DM_DM_MULT_NBUCKET,
-                                 stochPackageConfig::CT_DM_ADD_NBUCKET,
-                                 stochPackageConfig::STOCHASTIC_CACHE_OPS>;
+using stochPackage = dd::Package<StochPackageConfig::UT_VEC_NBUCKET,
+                                 StochPackageConfig::UT_VEC_INITIAL_ALLOCATION_SIZE,
+                                 StochPackageConfig::UT_MAT_NBUCKET,
+                                 StochPackageConfig::UT_MAT_INITIAL_ALLOCATION_SIZE,
+                                 StochPackageConfig::CT_VEC_ADD_NBUCKET,
+                                 StochPackageConfig::CT_MAT_ADD_NBUCKET,
+                                 StochPackageConfig::CT_MAT_TRANS_NBUCKET,
+                                 StochPackageConfig::CT_MAT_CONJ_TRANS_NBUCKET,
+                                 StochPackageConfig::CT_MAT_VEC_MULT_NBUCKET,
+                                 StochPackageConfig::CT_MAT_MAT_MULT_NBUCKET,
+                                 StochPackageConfig::CT_VEC_KRON_NBUCKET,
+                                 StochPackageConfig::CT_MAT_KRON_NBUCKET,
+                                 StochPackageConfig::CT_VEC_INNER_PROD_NBUCKET,
+                                 StochPackageConfig::CT_DM_NOISE_NBUCKET,
+                                 StochPackageConfig::UT_DM_NBUCKET,
+                                 StochPackageConfig::UT_DM_INITIAL_ALLOCATION_SIZE,
+                                 StochPackageConfig::CT_DM_DM_MULT_NBUCKET,
+                                 StochPackageConfig::CT_DM_ADD_NBUCKET,
+                                 StochPackageConfig::STOCHASTIC_CACHE_OPS>;
 
 TEST(DDPackageTest, dStochCache) {
-    dd::Qubit nr_qubits = 4;
-    auto      dd        = std::make_unique<stochPackage>(nr_qubits);
+    const dd::Qubit nrQubits = 4;
+    auto      dd        = std::make_unique<stochPackage>(nrQubits);
 
     std::vector<dd::mEdge> operations = {};
-    operations.emplace_back(dd->makeGateDD(dd::Xmat, nr_qubits, 0));
-    operations.emplace_back(dd->makeGateDD(dd::Zmat, nr_qubits, 1));
-    operations.emplace_back(dd->makeGateDD(dd::Ymat, nr_qubits, 2));
-    operations.emplace_back(dd->makeGateDD(dd::Hmat, nr_qubits, 3));
+    operations.emplace_back(dd->makeGateDD(dd::Xmat, nrQubits, 0));
+    operations.emplace_back(dd->makeGateDD(dd::Zmat, nrQubits, 1));
+    operations.emplace_back(dd->makeGateDD(dd::Ymat, nrQubits, 2));
+    operations.emplace_back(dd->makeGateDD(dd::Hmat, nrQubits, 3));
 
     dd->stochasticNoiseOperationCache.insert(0, 0, operations[0]); //insert X operations with target 0
     dd->stochasticNoiseOperationCache.insert(1, 1, operations[1]); //insert Z operations with target 1
@@ -1347,7 +1354,7 @@ TEST(DDPackageTest, complexRefCount) {
     auto value = dd->cn.lookup(0.2, 0.2);
     EXPECT_EQ(value.r->refCount, 0);
     EXPECT_EQ(value.i->refCount, 0);
-    dd->cn.incRef(value);
+    decltype(dd->cn)::incRef(value);
     EXPECT_EQ(value.r->refCount, 2);
     EXPECT_EQ(value.i->refCount, 2);
 }

--- a/test/test_package.cpp
+++ b/test/test_package.cpp
@@ -169,7 +169,7 @@ TEST(DDPackageTest, NegativeControl) {
 
     auto xGate     = dd->makeGateDD(dd::Xmat, 2, 1_nc, 0);
     auto zeroState = dd->makeZeroState(2);
-    auto state01    = dd->multiply(xGate, zeroState);
+    auto state01   = dd->multiply(xGate, zeroState);
     EXPECT_EQ(dd->getValueByPath(state01, 0b01).r, 1.);
 }
 
@@ -189,8 +189,8 @@ TEST(DDPackageTest, PartialIdentityTrace) {
 
 TEST(DDPackageTest, StateGenerationManipulation) {
     std::size_t nqubits = 6;
-    auto           dd      = std::make_unique<dd::Package<>>(nqubits);
-    auto           b       = std::vector<bool>(nqubits, false);
+    auto        dd      = std::make_unique<dd::Package<>>(nqubits);
+    auto        b       = std::vector<bool>(nqubits, false);
     b[0] = b[1] = true;
     auto e      = dd->makeBasisState(nqubits, b);
     auto f      = dd->makeBasisState(nqubits, {dd::BasisStates::zero, dd::BasisStates::one, dd::BasisStates::plus, dd::BasisStates::minus, dd::BasisStates::left, dd::BasisStates::right});
@@ -254,10 +254,10 @@ TEST(DDPackageTest, BellMatrix) {
     ASSERT_EQ(dd->getValueByPath(bellMatrix, 2, 3), (dd::ComplexValue{-dd::SQRT2_2, 0}));
     ASSERT_EQ(dd->getValueByPath(bellMatrix, 3, 3), (dd::ComplexValue{0, 0}));
 
-    auto goalRow0  = dd::CVec{{dd::SQRT2_2, 0.}, {0., 0.}, {dd::SQRT2_2, 0.}, {0., 0.}};
-    auto goalRow1  = dd::CVec{{0., 0.}, {dd::SQRT2_2, 0.}, {0., 0.}, {dd::SQRT2_2, 0.}};
-    auto goalRow2  = dd::CVec{{0., 0.}, {dd::SQRT2_2, 0.}, {0., 0.}, {-dd::SQRT2_2, 0.}};
-    auto goalRow3  = dd::CVec{{dd::SQRT2_2, 0.}, {0., 0.}, {-dd::SQRT2_2, 0.}, {0., 0.}};
+    auto goalRow0   = dd::CVec{{dd::SQRT2_2, 0.}, {0., 0.}, {dd::SQRT2_2, 0.}, {0., 0.}};
+    auto goalRow1   = dd::CVec{{0., 0.}, {dd::SQRT2_2, 0.}, {0., 0.}, {dd::SQRT2_2, 0.}};
+    auto goalRow2   = dd::CVec{{0., 0.}, {dd::SQRT2_2, 0.}, {0., 0.}, {-dd::SQRT2_2, 0.}};
+    auto goalRow3   = dd::CVec{{dd::SQRT2_2, 0.}, {0., 0.}, {-dd::SQRT2_2, 0.}, {0., 0.}};
     auto goalMatrix = dd::CMat{goalRow0, goalRow1, goalRow2, goalRow3};
     ASSERT_EQ(dd->getMatrix(bellMatrix), goalMatrix);
 
@@ -437,27 +437,27 @@ TEST(DDPackageTest, TestLocalInconsistency) {
     auto zeroState = dd->makeZeroState(2);
 
     auto bellState = dd->multiply(dd->multiply(cxGate, hGate), zeroState);
-    auto local      = dd->isLocallyConsistent(bellState);
+    auto local     = dd->isLocallyConsistent(bellState);
     EXPECT_FALSE(local);
     bellState.p->ref = 1;
-    local             = dd->isLocallyConsistent(bellState);
+    local            = dd->isLocallyConsistent(bellState);
     EXPECT_FALSE(local);
     bellState.p->ref = 0;
     dd->incRef(bellState);
 
     bellState.p->v = 2;
-    local           = dd->isLocallyConsistent(bellState);
+    local          = dd->isLocallyConsistent(bellState);
     EXPECT_FALSE(local);
     bellState.p->v = 1;
 
     bellState.p->e[0].w.r->refCount = 0;
-    local                            = dd->isLocallyConsistent(bellState);
+    local                           = dd->isLocallyConsistent(bellState);
     EXPECT_FALSE(local);
     bellState.p->e[0].w.r->refCount = 1;
 }
 
 TEST(DDPackageTest, Ancillaries) {
-    auto dd          = std::make_unique<dd::Package<>>(4);
+    auto dd         = std::make_unique<dd::Package<>>(4);
     auto hGate      = dd->makeGateDD(dd::Hmat, 2, 0);
     auto cxGate     = dd->makeGateDD(dd::Xmat, 2, 0_pc, 1);
     auto bellMatrix = dd->multiply(cxGate, hGate);
@@ -494,7 +494,7 @@ TEST(DDPackageTest, Ancillaries) {
 }
 
 TEST(DDPackageTest, GarbageVector) {
-    auto dd         = std::make_unique<dd::Package<>>(4);
+    auto dd        = std::make_unique<dd::Package<>>(4);
     auto hGate     = dd->makeGateDD(dd::Hmat, 2, 0);
     auto cxGate    = dd->makeGateDD(dd::Xmat, 2, 0_pc, 1);
     auto zeroState = dd->makeZeroState(2);
@@ -510,7 +510,7 @@ TEST(DDPackageTest, GarbageVector) {
 
     dd->incRef(bellState);
     reducedBellState = dd->reduceGarbage(bellState, {false, true, false, false});
-    auto vec           = dd->getVector(reducedBellState);
+    auto vec         = dd->getVector(reducedBellState);
     dd->printVector(reducedBellState);
     EXPECT_EQ(vec[2], static_cast<std::complex<dd::fp>>(dd::complex_zero));
     EXPECT_EQ(vec[3], static_cast<std::complex<dd::fp>>(dd::complex_zero));
@@ -524,7 +524,7 @@ TEST(DDPackageTest, GarbageVector) {
 }
 
 TEST(DDPackageTest, GarbageMatrix) {
-    auto dd          = std::make_unique<dd::Package<>>(4);
+    auto dd         = std::make_unique<dd::Package<>>(4);
     auto hGate      = dd->makeGateDD(dd::Hmat, 2, 0);
     auto cxGate     = dd->makeGateDD(dd::Xmat, 2, 0_pc, 1);
     auto bellMatrix = dd->multiply(cxGate, hGate);
@@ -538,14 +538,14 @@ TEST(DDPackageTest, GarbageMatrix) {
 
     dd->incRef(bellMatrix);
     reducedBellMatrix = dd->reduceGarbage(bellMatrix, {false, true, false, false});
-    auto mat            = dd->getMatrix(reducedBellMatrix);
-    auto zero           = dd::CVec{{0., 0.}, {0., 0.}, {0., 0.}, {0., 0.}};
+    auto mat          = dd->getMatrix(reducedBellMatrix);
+    auto zero         = dd::CVec{{0., 0.}, {0., 0.}, {0., 0.}, {0., 0.}};
     EXPECT_EQ(mat[2], zero);
     EXPECT_EQ(mat[3], zero);
 
     dd->incRef(bellMatrix);
     reducedBellMatrix = dd->reduceGarbage(bellMatrix, {true, false, false, false});
-    mat                 = dd->getMatrix(reducedBellMatrix);
+    mat               = dd->getMatrix(reducedBellMatrix);
     EXPECT_EQ(mat[1], zero);
     EXPECT_EQ(mat[3], zero);
 
@@ -576,7 +576,7 @@ TEST(DDPackageTest, PackageReset) {
     auto dd = std::make_unique<dd::Package<>>(1);
 
     // one node in unique table of variable 0
-    auto        iGate = dd->makeIdent(1);
+    auto        iGate  = dd->makeIdent(1);
     const auto& unique = dd->mUniqueTable.getTables();
     const auto& table  = unique[0];
     auto        ihash  = decltype(dd->mUniqueTable)::hash(iGate.p);
@@ -587,7 +587,7 @@ TEST(DDPackageTest, PackageReset) {
     dd->reset();
     // after clearing the tables, they should be empty
     EXPECT_EQ(table[ihash], nullptr);
-    iGate            = dd->makeIdent(1);
+    iGate             = dd->makeIdent(1);
     const auto* node2 = table[ihash];
     // after recreating the DD, it should receive the same node
     EXPECT_EQ(node2, node);
@@ -632,7 +632,7 @@ TEST(DDPackageTest, UniqueTableAllocation) {
     }
 
     // trigger new allocation
-    [[maybe_unused]] auto *node = dd->vUniqueTable.getNode();
+    [[maybe_unused]] auto* node = dd->vUniqueTable.getNode();
     EXPECT_EQ(dd->vUniqueTable.getAllocations(), (1. + dd->vUniqueTable.getGrowthFactor()) * allocs);
 
     // clearing the unique table should reduce the allocated size to the original size
@@ -946,8 +946,8 @@ TEST(DDPackageTest, ExportConditionalFormat) {
 TEST(DDPackageTest, BasicNumericInstabilityTest) {
     const dd::fp zero = 0.0;
     const dd::fp half = 0.5;
-    const dd::fp one = 1.0;
-    const dd::fp two = 2.0;
+    const dd::fp one  = 1.0;
+    const dd::fp two  = 2.0;
 
     std::cout << std::setprecision(std::numeric_limits<dd::fp>::max_digits10);
 
@@ -1161,7 +1161,7 @@ TEST(DDPackageTest, dNodeMultiply) {
 TEST(DDPackageTest, dNodeMultiply2) {
     //Multiply dNode with mNode (MxMxM)
     const dd::Qubit nrQubits = 3;
-    auto      dd        = std::make_unique<DensityMatrixPackageTest>(nrQubits);
+    auto            dd       = std::make_unique<DensityMatrixPackageTest>(nrQubits);
     // Make zero density matrix
     auto state = dd->makeZeroDensityOperator(dd->qubits());
     dd->incRef(state);
@@ -1200,7 +1200,7 @@ TEST(DDPackageTest, dNodeMultiply2) {
 TEST(DDPackageTest, dNodeMulCache1) {
     // Make caching test with dNodes
     const dd::Qubit nrQubits = 1;
-    auto      dd        = std::make_unique<DensityMatrixPackageTest>(nrQubits);
+    auto            dd       = std::make_unique<DensityMatrixPackageTest>(nrQubits);
     // Make zero density matrix
     auto state = dd->makeZeroDensityOperator(dd->qubits());
     dd->incRef(state);
@@ -1211,7 +1211,7 @@ TEST(DDPackageTest, dNodeMulCache1) {
     for (auto& op: operations) {
         auto tmp0 = dd->conjugateTranspose(op);
         auto tmp1 = dd->multiply(state, reinterpret_cast<dd::dEdge&>(tmp0), 0, false); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-        auto tmp2 = dd->multiply(reinterpret_cast<dd::dEdge&>(op), tmp1, 0, false); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+        auto tmp2 = dd->multiply(reinterpret_cast<dd::dEdge&>(op), tmp1, 0, false);    // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
         dd->incRef(tmp2);
         state = tmp2;
     }
@@ -1229,7 +1229,7 @@ TEST(DDPackageTest, dNodeMulCache1) {
         yCopy.w    = dd::Complex::one;
 
         auto tmptmp1 = computeTable.lookup(xCopy, yCopy, false);
-        auto tmp1  = dd->multiply(state1, reinterpret_cast<dd::dEdge&>(tmp0), 0, false); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+        auto tmp1    = dd->multiply(state1, reinterpret_cast<dd::dEdge&>(tmp0), 0, false); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
         EXPECT_TRUE(tmp1.p != nullptr && tmp1.p == tmp1.p);
 
         auto xCopy1 = reinterpret_cast<dd::dEdge&>(op); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
@@ -1238,7 +1238,7 @@ TEST(DDPackageTest, dNodeMulCache1) {
         yCopy1.w    = dd::Complex::one;
 
         auto tmptmp2 = computeTable.lookup(xCopy1, yCopy1, true);
-        auto tmp2  = dd->multiply(reinterpret_cast<dd::dEdge&>(op), tmp1, 0, true); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+        auto tmp2    = dd->multiply(reinterpret_cast<dd::dEdge&>(op), tmp1, 0, true); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
         EXPECT_EQ(tmptmp2.p, nullptr);
 
         auto tmptmp3 = computeTable.lookup(xCopy1, yCopy1, true);
@@ -1253,7 +1253,7 @@ TEST(DDPackageTest, dNodeMulCache1) {
 TEST(DDPackageTest, dNoiseCache) {
     // Test the flags for dnode, vnode and mnodes
     const dd::Qubit nrQubits = 1;
-    auto      dd        = std::make_unique<dd::Package<>>(nrQubits);
+    auto            dd       = std::make_unique<dd::Package<>>(nrQubits);
     // Make zero density matrix
     auto state = dd->makeZeroDensityOperator(dd->qubits());
     dd->incRef(state);
@@ -1266,7 +1266,7 @@ TEST(DDPackageTest, dNoiseCache) {
     auto noiseLookUpResult = dd->densityNoise.lookup(state, target);
     EXPECT_EQ(noiseLookUpResult.p, nullptr);
     auto tmp0 = dd->conjugateTranspose(operations[0]);
-    auto tmp1 = dd->multiply(state, reinterpret_cast<dd::dEdge&>(tmp0), 0, false); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto tmp1 = dd->multiply(state, reinterpret_cast<dd::dEdge&>(tmp0), 0, false);        // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
     auto tmp2 = dd->multiply(reinterpret_cast<dd::dEdge&>(operations[0]), tmp1, 0, true); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
     dd->incRef(tmp2);
     auto state1 = tmp2;
@@ -1282,9 +1282,9 @@ TEST(DDPackageTest, dNoiseCache) {
 
 TEST(DDPackageTest, calCulpDistance) {
     dd::Qubit nrQubits = 1;
-    auto      dd        = std::make_unique<dd::Package<>>(nrQubits);
-    auto      tmp0      = dd::ulpDistance(1 + 1e-12, 1);
-    auto      tmp1      = dd::ulpDistance(1, 1);
+    auto      dd       = std::make_unique<dd::Package<>>(nrQubits);
+    auto      tmp0     = dd::ulpDistance(1 + 1e-12, 1);
+    auto      tmp1     = dd::ulpDistance(1, 1);
     EXPECT_TRUE(tmp0 > 0);
     EXPECT_EQ(tmp1, 0);
 }
@@ -1315,7 +1315,7 @@ using stochPackage = dd::Package<StochPackageConfig::UT_VEC_NBUCKET,
 
 TEST(DDPackageTest, dStochCache) {
     const dd::Qubit nrQubits = 4;
-    auto      dd        = std::make_unique<stochPackage>(nrQubits);
+    auto            dd       = std::make_unique<stochPackage>(nrQubits);
 
     std::vector<dd::mEdge> operations = {};
     operations.emplace_back(dd->makeGateDD(dd::Xmat, nrQubits, 0));

--- a/test/test_package.cpp
+++ b/test/test_package.cpp
@@ -418,7 +418,7 @@ TEST(DDPackageTest, Identity) {
     const auto& table = dd->getIdentityTable();
     EXPECT_NE(table[2].p, nullptr);
 
-    auto id2 = dd->makeIdent(0, 1); // should be found in IdTable
+    auto id2 = dd->makeIdent(0, 1); // should be found in idTable
     EXPECT_EQ(dd->makeIdent(2), id2);
 
     auto id4 = dd->makeIdent(0, 3); // should use id3 and extend it

--- a/test/test_package.cpp
+++ b/test/test_package.cpp
@@ -312,9 +312,9 @@ TEST(DDPackageTest, SerializationErrors) {
 
     ss.str("");
     std::remove_const_t<decltype(dd::SERIALIZATION_VERSION)> version = 2;
-    ss.write(reinterpret_cast<const char*>(&version), sizeof(decltype(dd::SERIALIZATION_VERSION))); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+    ss.write(reinterpret_cast<const char*>(&version), sizeof(decltype(dd::SERIALIZATION_VERSION)));
     EXPECT_THROW(dd->deserialize<dd::vNode>(ss, true), std::runtime_error);
-    ss.write(reinterpret_cast<const char*>(&version), sizeof(decltype(dd::SERIALIZATION_VERSION))); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+    ss.write(reinterpret_cast<const char*>(&version), sizeof(decltype(dd::SERIALIZATION_VERSION)));
     EXPECT_THROW(dd->deserialize<dd::mNode>(ss, true), std::runtime_error);
 
     // test wrong format
@@ -581,7 +581,7 @@ TEST(DDPackageTest, PackageReset) {
     const auto& table  = unique[0];
     auto        ihash  = decltype(dd->mUniqueTable)::hash(iGate.p);
     const auto* node   = table[ihash];
-    std::cout << ihash << ": " << reinterpret_cast<uintptr_t>(iGate.p) << std::endl; // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+    std::cout << ihash << ": " << reinterpret_cast<uintptr_t>(iGate.p) << std::endl;
     // node should be the first in this unique table bucket
     EXPECT_EQ(node, iGate.p);
     dd->reset();
@@ -1210,8 +1210,8 @@ TEST(DDPackageTest, dNodeMulCache1) {
 
     for (auto& op: operations) {
         auto tmp0 = dd->conjugateTranspose(op);
-        auto tmp1 = dd->multiply(state, reinterpret_cast<dd::dEdge&>(tmp0), 0, false); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-        auto tmp2 = dd->multiply(reinterpret_cast<dd::dEdge&>(op), tmp1, 0, false);    // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+        auto tmp1 = dd->multiply(state, reinterpret_cast<dd::dEdge&>(tmp0), 0, false);
+        auto tmp2 = dd->multiply(reinterpret_cast<dd::dEdge&>(op), tmp1, 0, false);
         dd->incRef(tmp2);
         state = tmp2;
     }
@@ -1225,20 +1225,20 @@ TEST(DDPackageTest, dNodeMulCache1) {
 
         auto xCopy = state1;
         xCopy.w    = dd::Complex::one;
-        auto yCopy = reinterpret_cast<dd::dEdge&>(tmp0); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+        auto yCopy = reinterpret_cast<dd::dEdge&>(tmp0);
         yCopy.w    = dd::Complex::one;
 
         auto tmptmp1 = computeTable.lookup(xCopy, yCopy, false);
-        auto tmp1    = dd->multiply(state1, reinterpret_cast<dd::dEdge&>(tmp0), 0, false); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-        EXPECT_TRUE(tmp1.p != nullptr && tmp1.p == tmp1.p);
+        auto tmp1    = dd->multiply(state1, reinterpret_cast<dd::dEdge&>(tmp0), 0, false);
+        EXPECT_TRUE(tmptmp1.p != nullptr && tmp1.p == tmptmp1.p);
 
-        auto xCopy1 = reinterpret_cast<dd::dEdge&>(op); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+        auto xCopy1 = reinterpret_cast<dd::dEdge&>(op);
         xCopy1.w    = dd::Complex::one;
         auto yCopy1 = tmp1;
         yCopy1.w    = dd::Complex::one;
 
         auto tmptmp2 = computeTable.lookup(xCopy1, yCopy1, true);
-        auto tmp2    = dd->multiply(reinterpret_cast<dd::dEdge&>(op), tmp1, 0, true); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+        auto tmp2    = dd->multiply(reinterpret_cast<dd::dEdge&>(op), tmp1, 0, true);
         EXPECT_EQ(tmptmp2.p, nullptr);
 
         auto tmptmp3 = computeTable.lookup(xCopy1, yCopy1, true);
@@ -1266,8 +1266,8 @@ TEST(DDPackageTest, dNoiseCache) {
     auto noiseLookUpResult = dd->densityNoise.lookup(state, target);
     EXPECT_EQ(noiseLookUpResult.p, nullptr);
     auto tmp0 = dd->conjugateTranspose(operations[0]);
-    auto tmp1 = dd->multiply(state, reinterpret_cast<dd::dEdge&>(tmp0), 0, false);        // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-    auto tmp2 = dd->multiply(reinterpret_cast<dd::dEdge&>(operations[0]), tmp1, 0, true); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto tmp1 = dd->multiply(state, reinterpret_cast<dd::dEdge&>(tmp0), 0, false);
+    auto tmp2 = dd->multiply(reinterpret_cast<dd::dEdge&>(operations[0]), tmp1, 0, true);
     dd->incRef(tmp2);
     auto state1 = tmp2;
     dd->densityNoise.insert(state, state1, target);


### PR DESCRIPTION
This PR introduces a new CI job to check for compliance via Clang Tidy.

This includes checking variable and function names, warnings for C-style casts and a few more.

(Recreated from #103)