### PR TITLE
🐛 Fix unicode literals for C++20

### DIFF
--- a/include/dd/Export.hpp
+++ b/include/dd/Export.hpp
@@ -229,7 +229,7 @@ namespace dd {
                 if (e.w.r == &ComplexTable<>::zero) {
                     os << "0";
                 } else if (e.w.r == &ComplexTable<>::sqrt2_2) {
-                    os << u8"\u221a\u00bd";
+                    os << "\xe2\x88\x9a\xc2\xbd";
                 } else if (e.w.r == &ComplexTable<>::one) {
                     os << "1";
                 } else {
@@ -239,7 +239,7 @@ namespace dd {
                 if (e.w.i == &ComplexTable<>::zero) {
                     os << "0";
                 } else if (e.w.i == &ComplexTable<>::sqrt2_2) {
-                    os << u8"\u221a\u00bd";
+                    os << "\xe2\x88\x9a\xc2\xbd";
                 } else if (e.w.i == &ComplexTable<>::one) {
                     os << "1";
                 } else {
@@ -512,7 +512,7 @@ namespace dd {
                 if (to.w.r == &ComplexTable<>::zero) {
                     os << "0";
                 } else if (to.w.r == &ComplexTable<>::sqrt2_2) {
-                    os << u8"\u221a\u00bd";
+                    os << "\xe2\x88\x9a\xc2\xbd";
                 } else if (to.w.r == &ComplexTable<>::one) {
                     os << "1";
                 } else {
@@ -522,7 +522,7 @@ namespace dd {
                 if (to.w.i == &ComplexTable<>::zero) {
                     os << "0";
                 } else if (to.w.i == &ComplexTable<>::sqrt2_2) {
-                    os << u8"\u221a\u00bd";
+                    os << "\xe2\x88\x9a\xc2\xbd";
                 } else if (to.w.i == &ComplexTable<>::one) {
                     os << "1";
                 } else {


### PR DESCRIPTION
This PR fixes a bug occurring under C++20 involving unicode literals and UTF-8 strings. For further context, see https://stackoverflow.com/questions/56833000/c20-with-u8-char8-t-and-stdstring). The workaround is taken from https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1423r2.html.