### PR TITLE
🐛 Fix for upstream LTO internal compiler error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,8 +66,13 @@ if(MSVC)
 else()
   target_compile_options(
     ${PROJECT_NAME}
-    INTERFACE -Wall -Wextra -pedantic -g $<$<CONFIG:DEBUG>:-Og>$<$<CONFIG:RELEASE>:-fno-math-errno
-              -ffinite-math-only -fno-trapping-math>)
+    INTERFACE -Wall
+              -Wextra
+              -pedantic
+              -g
+              $<$<CONFIG:DEBUG>:-Og>$<$<CONFIG:RELEASE>:-fno-math-errno
+              -ffinite-math-only
+              -fno-trapping-math>)
   if(NOT DEPLOY)
     # only include machine-specific optimizations when building for the host machine
     target_compile_options(${PROJECT_NAME} INTERFACE -mtune=native)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,13 +89,11 @@ endif()
 # add MQT alias
 add_library(MQT::DDPackage ALIAS ${PROJECT_NAME})
 
-# enable interprocedural optimization if it is supported (Clang's ThinLTO does not work with Ubuntu
-# 20.04's default linker at the moment)
+# enable interprocedural optimization if it is supported
 macro(ENABLE_LTO target_name)
   include(CheckIPOSupported)
   check_ipo_supported(RESULT ipo_supported)
-  if(ipo_supported AND NOT ((${CMAKE_SYSTEM_NAME} MATCHES "Linux") AND (${CMAKE_CXX_COMPILER_ID}
-                                                                        MATCHES "Clang")))
+  if(ipo_supported)
     set_target_properties(${target_name} PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
   endif()
 endmacro()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ if(MSVC)
 else()
   target_compile_options(
     ${PROJECT_NAME}
-    INTERFACE -Wall -Wextra -pedantic $<$<CONFIG:DEBUG>:-Og>$<$<CONFIG:RELEASE>:-fno-math-errno
+    INTERFACE -Wall -Wextra -pedantic -g $<$<CONFIG:DEBUG>:-Og>$<$<CONFIG:RELEASE>:-fno-math-errno
               -ffinite-math-only -fno-trapping-math>)
   if(NOT DEPLOY)
     # only include machine-specific optimizations when building for the host machine


### PR DESCRIPTION
https://github.com/cda-tum/qmap/pull/203 has shown that one of the recent updates in the core repositories has introduced a new internal compiler error situation. Bisecting the cause for the error lead to https://github.com/cda-tum/dd_package/pull/122, which, at first, was quite surprising.
It turns out that https://github.com/cda-tum/dd_package/pull/122 rather unintentionally fixed a bug in the `enable_lto` macro which led to LTO not being enabled at all.
Thus, the failure in https://github.com/cda-tum/qmap/pull/203 is a consequence of LTO being properly enabled.

After experimenting a little bit and googling around, it turns out that unconditionally adding debug symbols (i.e., `-g`) resolves the underlying error.