### PR TITLE
🚸 Better DD package templating

### DIFF
--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -75,26 +75,9 @@ namespace dd {
         static constexpr std::size_t STOCHASTIC_CACHE_OPS = 1;
     };
 
-    template<std::size_t UT_VEC_NBUCKET                 = DDPackageConfig::UT_VEC_NBUCKET,
-             std::size_t UT_VEC_INITIAL_ALLOCATION_SIZE = DDPackageConfig::UT_VEC_INITIAL_ALLOCATION_SIZE,
-             std::size_t UT_MAT_NBUCKET                 = DDPackageConfig::UT_MAT_NBUCKET,
-             std::size_t UT_MAT_INITIAL_ALLOCATION_SIZE = DDPackageConfig::UT_MAT_INITIAL_ALLOCATION_SIZE,
-             std::size_t CT_VEC_ADD_NBUCKET             = DDPackageConfig::CT_VEC_ADD_NBUCKET,
-             std::size_t CT_MAT_ADD_NBUCKET             = DDPackageConfig::CT_MAT_ADD_NBUCKET,
-             std::size_t CT_MAT_TRANS_NBUCKET           = DDPackageConfig::CT_MAT_TRANS_NBUCKET,
-             std::size_t CT_MAT_CONJ_TRANS_NBUCKET      = DDPackageConfig::CT_MAT_CONJ_TRANS_NBUCKET,
-             std::size_t CT_MAT_VEC_MULT_NBUCKET        = DDPackageConfig::CT_MAT_VEC_MULT_NBUCKET,
-             std::size_t CT_MAT_MAT_MULT_NBUCKET        = DDPackageConfig::CT_MAT_MAT_MULT_NBUCKET,
-             std::size_t CT_VEC_KRON_NBUCKET            = DDPackageConfig::CT_VEC_KRON_NBUCKET,
-             std::size_t CT_MAT_KRON_NBUCKET            = DDPackageConfig::CT_MAT_KRON_NBUCKET,
-             std::size_t CT_VEC_INNER_PROD_NBUCKET      = DDPackageConfig::CT_VEC_INNER_PROD_NBUCKET,
-             std::size_t CT_DM_NOISE_NBUCKET            = DDPackageConfig::CT_DM_NOISE_NBUCKET,
-             std::size_t UT_DM_NBUCKET                  = DDPackageConfig::UT_DM_NBUCKET,
-             std::size_t UT_DM_INITIAL_ALLOCATION_SIZE  = DDPackageConfig::UT_DM_INITIAL_ALLOCATION_SIZE,
-             std::size_t CT_DM_DM_MULT_NBUCKET          = DDPackageConfig::CT_DM_DM_MULT_NBUCKET,
-             std::size_t CT_DM_ADD_NBUCKET              = DDPackageConfig::CT_DM_ADD_NBUCKET,
-             std::size_t STOCHASTIC_CACHE_OPS           = DDPackageConfig::STOCHASTIC_CACHE_OPS>
+    template<class Config = DDPackageConfig>
     class Package {
+        static_assert(std::is_base_of_v<DDPackageConfig, Config>, "Config must be derived from DDPackageConfig");
         ///
         /// Complex number handling
         ///
@@ -589,9 +572,9 @@ namespace dd {
             getUniqueTable<Node>().decRef(e);
         }
 
-        UniqueTable<vNode, UT_VEC_NBUCKET, UT_VEC_INITIAL_ALLOCATION_SIZE> vUniqueTable{nqubits};
-        UniqueTable<mNode, UT_MAT_NBUCKET, UT_MAT_INITIAL_ALLOCATION_SIZE> mUniqueTable{nqubits};
-        UniqueTable<dNode, UT_DM_NBUCKET, UT_DM_INITIAL_ALLOCATION_SIZE>   dUniqueTable{nqubits};
+        UniqueTable<vNode, Config::UT_VEC_NBUCKET, Config::UT_VEC_INITIAL_ALLOCATION_SIZE> vUniqueTable{nqubits};
+        UniqueTable<mNode, Config::UT_MAT_NBUCKET, Config::UT_MAT_INITIAL_ALLOCATION_SIZE> mUniqueTable{nqubits};
+        UniqueTable<dNode, Config::UT_DM_NBUCKET, Config::UT_DM_INITIAL_ALLOCATION_SIZE>   dUniqueTable{nqubits};
 
         bool garbageCollect(bool force = false) {
             // return immediately if no table needs collection
@@ -963,9 +946,9 @@ namespace dd {
         ///
         /// Addition
         ///
-        ComputeTable<vCachedEdge, vCachedEdge, vCachedEdge, CT_VEC_ADD_NBUCKET> vectorAdd{};
-        ComputeTable<mCachedEdge, mCachedEdge, mCachedEdge, CT_MAT_ADD_NBUCKET> matrixAdd{};
-        ComputeTable<dCachedEdge, dCachedEdge, dCachedEdge, CT_DM_ADD_NBUCKET>  densityAdd{};
+        ComputeTable<vCachedEdge, vCachedEdge, vCachedEdge, Config::CT_VEC_ADD_NBUCKET> vectorAdd{};
+        ComputeTable<mCachedEdge, mCachedEdge, mCachedEdge, Config::CT_MAT_ADD_NBUCKET> matrixAdd{};
+        ComputeTable<dCachedEdge, dCachedEdge, dCachedEdge, Config::CT_DM_ADD_NBUCKET>  densityAdd{};
 
         template<class Node>
         [[nodiscard]] auto& getAddComputeTable() {
@@ -1099,8 +1082,8 @@ namespace dd {
         ///
         /// Matrix (conjugate) transpose
         ///
-        UnaryComputeTable<mEdge, mEdge, CT_MAT_TRANS_NBUCKET>      matrixTranspose{};
-        UnaryComputeTable<mEdge, mEdge, CT_MAT_CONJ_TRANS_NBUCKET> conjugateMatrixTranspose{};
+        UnaryComputeTable<mEdge, mEdge, Config::CT_MAT_TRANS_NBUCKET>      matrixTranspose{};
+        UnaryComputeTable<mEdge, mEdge, Config::CT_MAT_CONJ_TRANS_NBUCKET> conjugateMatrixTranspose{};
 
         mEdge transpose(const mEdge& a) {
             if (a.p == nullptr || a.isTerminal() || a.p->isSymmetric()) {
@@ -1170,9 +1153,9 @@ namespace dd {
         ///
         /// Multiplication
         ///
-        ComputeTable<mEdge, vEdge, vCachedEdge, CT_MAT_VEC_MULT_NBUCKET> matrixVectorMultiplication{};
-        ComputeTable<mEdge, mEdge, mCachedEdge, CT_MAT_MAT_MULT_NBUCKET> matrixMatrixMultiplication{};
-        ComputeTable<dEdge, dEdge, dCachedEdge, CT_DM_DM_MULT_NBUCKET>   densityDensityMultiplication{};
+        ComputeTable<mEdge, vEdge, vCachedEdge, Config::CT_MAT_VEC_MULT_NBUCKET> matrixVectorMultiplication{};
+        ComputeTable<mEdge, mEdge, mCachedEdge, Config::CT_MAT_MAT_MULT_NBUCKET> matrixMatrixMultiplication{};
+        ComputeTable<dEdge, dEdge, dCachedEdge, Config::CT_DM_DM_MULT_NBUCKET>   densityDensityMultiplication{};
 
         template<class LeftOperandNode, class RightOperandNode>
         [[nodiscard]] auto& getMultiplicationComputeTable() {
@@ -1430,7 +1413,7 @@ namespace dd {
         /// Inner product and fidelity
         ///
     public:
-        ComputeTable<vEdge, vEdge, vCachedEdge, CT_VEC_INNER_PROD_NBUCKET> vectorInnerProduct{};
+        ComputeTable<vEdge, vEdge, vCachedEdge, Config::CT_VEC_INNER_PROD_NBUCKET> vectorInnerProduct{};
 
         ComplexValue innerProduct(const vEdge& x, const vEdge& y) {
             if (x.p == nullptr || y.p == nullptr || x.w.approximatelyZero() || y.w.approximatelyZero()) { // the 0 case
@@ -1547,8 +1530,8 @@ namespace dd {
         /// Kronecker/tensor product
         ///
     public:
-        ComputeTable<vEdge, vEdge, vCachedEdge, CT_VEC_KRON_NBUCKET> vectorKronecker{};
-        ComputeTable<mEdge, mEdge, mCachedEdge, CT_MAT_KRON_NBUCKET> matrixKronecker{};
+        ComputeTable<vEdge, vEdge, vCachedEdge, Config::CT_VEC_KRON_NBUCKET> vectorKronecker{};
+        ComputeTable<mEdge, mEdge, mCachedEdge, Config::CT_MAT_KRON_NBUCKET> matrixKronecker{};
 
         template<class Node>
         [[nodiscard]] auto& getKroneckerComputeTable() {
@@ -1844,8 +1827,8 @@ namespace dd {
         /// Noise Operations
         ///
     public:
-        StochasticNoiseOperationTable<mEdge, STOCHASTIC_CACHE_OPS> stochasticNoiseOperationCache{nqubits};
-        DensityNoiseTable<dEdge, dEdge, CT_DM_NOISE_NBUCKET>       densityNoise{};
+        StochasticNoiseOperationTable<mEdge, Config::STOCHASTIC_CACHE_OPS> stochasticNoiseOperationCache{nqubits};
+        DensityNoiseTable<dEdge, dEdge, Config::CT_DM_NOISE_NBUCKET>       densityNoise{};
 
         ///
         /// Decision diagram size

--- a/test/test_package.cpp
+++ b/test/test_package.cpp
@@ -1092,25 +1092,7 @@ struct DensityMatrixSimulatorDDPackageConfigTesting: public dd::DDPackageConfig 
     static constexpr std::size_t STOCHASTIC_CACHE_OPS           = 1U;
 };
 
-using DensityMatrixPackageTest = dd::Package<DensityMatrixSimulatorDDPackageConfigTesting::UT_VEC_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfigTesting::UT_VEC_INITIAL_ALLOCATION_SIZE,
-                                             DensityMatrixSimulatorDDPackageConfigTesting::UT_MAT_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfigTesting::UT_MAT_INITIAL_ALLOCATION_SIZE,
-                                             DensityMatrixSimulatorDDPackageConfigTesting::CT_VEC_ADD_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfigTesting::CT_MAT_ADD_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfigTesting::CT_MAT_TRANS_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfigTesting::CT_MAT_CONJ_TRANS_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfigTesting::CT_MAT_VEC_MULT_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfigTesting::CT_MAT_MAT_MULT_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfigTesting::CT_VEC_KRON_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfigTesting::CT_MAT_KRON_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfigTesting::CT_VEC_INNER_PROD_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfigTesting::CT_DM_NOISE_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfigTesting::UT_DM_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfigTesting::UT_DM_INITIAL_ALLOCATION_SIZE,
-                                             DensityMatrixSimulatorDDPackageConfigTesting::CT_DM_DM_MULT_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfigTesting::CT_DM_ADD_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfigTesting::STOCHASTIC_CACHE_OPS>;
+using DensityMatrixPackageTest = dd::Package<DensityMatrixSimulatorDDPackageConfigTesting>;
 
 TEST(DDPackageTest, dNodeMultiply) {
     //Multiply dNode with mNode (MxMxM)
@@ -1293,25 +1275,7 @@ struct StochPackageConfig: public dd::DDPackageConfig {
     static constexpr std::size_t STOCHASTIC_CACHE_OPS = 36;
 };
 
-using stochPackage = dd::Package<StochPackageConfig::UT_VEC_NBUCKET,
-                                 StochPackageConfig::UT_VEC_INITIAL_ALLOCATION_SIZE,
-                                 StochPackageConfig::UT_MAT_NBUCKET,
-                                 StochPackageConfig::UT_MAT_INITIAL_ALLOCATION_SIZE,
-                                 StochPackageConfig::CT_VEC_ADD_NBUCKET,
-                                 StochPackageConfig::CT_MAT_ADD_NBUCKET,
-                                 StochPackageConfig::CT_MAT_TRANS_NBUCKET,
-                                 StochPackageConfig::CT_MAT_CONJ_TRANS_NBUCKET,
-                                 StochPackageConfig::CT_MAT_VEC_MULT_NBUCKET,
-                                 StochPackageConfig::CT_MAT_MAT_MULT_NBUCKET,
-                                 StochPackageConfig::CT_VEC_KRON_NBUCKET,
-                                 StochPackageConfig::CT_MAT_KRON_NBUCKET,
-                                 StochPackageConfig::CT_VEC_INNER_PROD_NBUCKET,
-                                 StochPackageConfig::CT_DM_NOISE_NBUCKET,
-                                 StochPackageConfig::UT_DM_NBUCKET,
-                                 StochPackageConfig::UT_DM_INITIAL_ALLOCATION_SIZE,
-                                 StochPackageConfig::CT_DM_DM_MULT_NBUCKET,
-                                 StochPackageConfig::CT_DM_ADD_NBUCKET,
-                                 StochPackageConfig::STOCHASTIC_CACHE_OPS>;
+using stochPackage = dd::Package<StochPackageConfig>;
 
 TEST(DDPackageTest, dStochCache) {
     const dd::Qubit nrQubits = 4;


### PR DESCRIPTION
This PR simplifies the templating of the DD package.
For one, this reduces the redundancies in specifying a configuration and then duplicating all entries in the template list for the Package instance (which can also be a terrible source for errors).
In addition, this also allows to refactor all upstream code using 
```c++
template<class DDPackage = dd::Package<>> func(std::unique_ptr<DDPackage> dd)
```
to
```c++
template<class Config = dd::DDPackageConfig> func(std::unique_ptr<dd::Package<Config>> dd)
```
This allows IDEs to properly pick up the type of `dd` and offer code completion, proper error messages in proper places, and much more.

Corresponding PRs demonstrating the advantage are on their way for the QFR and QCEC.