### PR TITLE
✨ DDs from State Vectors

### DIFF
--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -315,7 +315,7 @@ namespace dd {
 
             [[maybe_unused]] const auto before = cn.cacheCount();
 
-            const auto level = static_cast<std::size_t>(std::log2(length)) - 1;
+            const auto level = static_cast<Qubit>(std::log2(length) - 1);
             auto       state = makeStateFromVector(stateVector.begin(), stateVector.end(), level);
 
             // the recursive function makes use of the cache, so we have to clean it up
@@ -575,7 +575,7 @@ namespace dd {
 
         vEdge makeStateFromVector(const CVec::const_iterator& begin,
                                   const CVec::const_iterator& end,
-                                  const std::size_t           level) {
+                                  const Qubit                 level) {
             if (level == 0) {
                 assert(std::distance(begin, end) == 2);
                 const auto& zeroWeight    = cn.getCached(begin->real(), begin->imag());
@@ -588,7 +588,7 @@ namespace dd {
             const auto half          = std::distance(begin, end) / 2;
             const auto zeroSuccessor = makeStateFromVector(begin, begin + half, level - 1);
             const auto oneSuccessor  = makeStateFromVector(begin + half, end, level - 1);
-            return makeDDNode<vNode>(static_cast<dd::Qubit>(level), {zeroSuccessor, oneSuccessor}, true);
+            return makeDDNode<vNode>(level, {zeroSuccessor, oneSuccessor}, true);
         }
 
         ///

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -313,6 +313,10 @@ namespace dd {
                 throw std::invalid_argument("State vector must have a length of a power of two.");
             }
 
+            if (length == 1) {
+                return vEdge::terminal(cn.lookup(stateVector[0].real(), stateVector[0].imag()));
+            }
+
             [[maybe_unused]] const auto before = cn.cacheCount();
 
             const auto level = static_cast<Qubit>(std::log2(length) - 1);

--- a/test/test_package.cpp
+++ b/test/test_package.cpp
@@ -1369,3 +1369,11 @@ TEST(DDPackageTest, stateFromVectorNoPowerOfTwo) {
     auto v  = std::vector<std::complex<dd::fp>>{1, 2, 3, 4, 5};
     EXPECT_THROW(dd->makeStateFromVector(v), std::invalid_argument);
 }
+
+TEST(DDPackageTest, stateFromScalar) {
+    auto dd = std::make_unique<dd::Package<>>(1);
+    auto s  = dd->makeStateFromVector({1});
+    EXPECT_EQ(s.p->v, -1);
+    EXPECT_EQ(s.w.r->value, 1);
+    EXPECT_EQ(s.w.i->value, 0);
+}

--- a/test/test_package.cpp
+++ b/test/test_package.cpp
@@ -1338,3 +1338,34 @@ TEST(DDPackageTest, exactlyOneComparison) {
     EXPECT_TRUE(!notOne.exactlyOne());
     EXPECT_TRUE(one.exactlyOne());
 }
+
+TEST(DDPackageTest, stateFromVectorBell) {
+    auto       dd = std::make_unique<dd::Package<>>(2);
+    const auto v  = std::vector<std::complex<dd::fp>>{dd::SQRT2_2, 0, 0, dd::SQRT2_2};
+    const auto s  = dd->makeStateFromVector(v);
+    EXPECT_EQ(s.p->v, 1);
+    EXPECT_EQ(s.p->e[0].w.r->value, dd::SQRT2_2);
+    EXPECT_EQ(s.p->e[0].w.i->value, 0);
+    EXPECT_EQ(s.p->e[1].w.r->value, dd::SQRT2_2);
+    EXPECT_EQ(s.p->e[1].w.i->value, 0);
+    EXPECT_EQ(s.p->e[0].p->e[0].w.r->value, 1);
+    EXPECT_EQ(s.p->e[0].p->e[0].w.i->value, 0);
+    EXPECT_EQ(s.p->e[0].p->e[1].w.r->value, 0);
+    EXPECT_EQ(s.p->e[0].p->e[1].w.i->value, 0);
+    EXPECT_EQ(s.p->e[1].p->e[0].w.r->value, 0);
+    EXPECT_EQ(s.p->e[1].p->e[0].w.i->value, 0);
+    EXPECT_EQ(s.p->e[1].p->e[1].w.r->value, 1);
+    EXPECT_EQ(s.p->e[1].p->e[1].w.i->value, 0);
+}
+
+TEST(DDPackageTest, stateFromVectorEmpty) {
+    auto dd = std::make_unique<dd::Package<>>(1);
+    auto v  = std::vector<std::complex<dd::fp>>{};
+    EXPECT_EQ(dd->makeStateFromVector(v), dd::vEdge::one);
+}
+
+TEST(DDPackageTest, stateFromVectorNoPowerOfTwo) {
+    auto dd = std::make_unique<dd::Package<>>(3);
+    auto v  = std::vector<std::complex<dd::fp>>{1, 2, 3, 4, 5};
+    EXPECT_THROW(dd->makeStateFromVector(v), std::invalid_argument);
+}


### PR DESCRIPTION
This PR adds a convenience function to the DD package that allows to create states from (dense) state vectors.
It uses the "textbook" recursive decomposition into halves to build up the DD.
In the future, this might be useful to export to Python, to make decision diagrams more accessible.