### PR TITLE
DDs from matrix

### DIFF
--- a/include/dd/ComplexNumbers.hpp
+++ b/include/dd/ComplexNumbers.hpp
@@ -186,7 +186,6 @@ namespace dd {
 
             return ret;
         }
-
         inline Complex lookup(const ComplexValue& c) { return lookup(c.r, c.i); }
 
         // reference counting and garbage collection

--- a/include/dd/ComplexNumbers.hpp
+++ b/include/dd/ComplexNumbers.hpp
@@ -235,7 +235,6 @@ namespace dd {
             return c;
         }
 
-
         inline Complex getCached(const ComplexValue& c) {
             return getCached(c.r, c.i);
         }

--- a/include/dd/ComplexNumbers.hpp
+++ b/include/dd/ComplexNumbers.hpp
@@ -150,6 +150,11 @@ namespace dd {
             auto vali = CTEntry::val(c.i);
             return lookup(valr, vali);
         }
+        Complex lookup(const std::complex<double>& c) {
+            auto valr = c.real();
+            auto vali = c.imag();
+            return lookup(valr, vali);
+        }
         Complex lookup(const fp& r, const fp& i) {
             Complex ret{};
 
@@ -181,6 +186,7 @@ namespace dd {
 
             return ret;
         }
+
         inline Complex lookup(const ComplexValue& c) { return lookup(c.r, c.i); }
 
         // reference counting and garbage collection

--- a/include/dd/ComplexNumbers.hpp
+++ b/include/dd/ComplexNumbers.hpp
@@ -235,8 +235,13 @@ namespace dd {
             return c;
         }
 
+
         inline Complex getCached(const ComplexValue& c) {
             return getCached(c.r, c.i);
+        }
+
+        inline Complex getCached(const std::complex<double>& c) {
+            return getCached(c.real(), c.imag());
         }
 
         void returnToCache(Complex& c) {

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -357,7 +357,7 @@ namespace dd {
                 throw std::invalid_argument("Matrix must be square.");
             }
 
-            if (length == 1 and width == 1) {
+            if (length == 1) {
                 return mEdge::terminal(cn.lookup(matrix[0][0].real(), matrix[0][0].imag()));
             }
 

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -668,18 +668,25 @@ namespace dd {
             CMat quad2 = CMat(static_cast<size_t>(half), CVec(static_cast<size_t>(half), {0.0, 0.0}));
             CMat quad3 = CMat(static_cast<size_t>(half), CVec(static_cast<size_t>(half), {0.0, 0.0}));
 
-            for (std::vector<double>::size_type i = 0; i < length; ++i) {
-                for (std::vector<double>::size_type j = 0; j < length; ++j) {
-                    if (i < half && j < half) {
-                        quad0[i % half][j % half] = matrix[i][j];
-                    } else if (i < half && j >= half) {
-                        quad1[i % half][j % half] = matrix[i][j];
-                    } else if (i >= half && j < half) {
-                        quad2[i % half][j % half] = matrix[i][j];
-                    } else if (i >= half && j >= half) {
-                        quad3[i % half][j % half] = matrix[i][j];
+            if (length > 1) {
+                for (std::vector<double>::size_type i = 0; i < length; ++i) {
+                    for (std::vector<double>::size_type j = 0; j < length; ++j) {
+                        if (i < half && j < half) {
+                            quad0[i % half][j % half] = matrix[i][j];
+                        } else if (i < half && j >= half) {
+                            quad1[i % half][j % half] = matrix[i][j];
+                        } else if (i >= half && j < half) {
+                            quad2[i % half][j % half] = matrix[i][j];
+                        } else if (i >= half && j >= half) {
+                            quad3[i % half][j % half] = matrix[i][j];
+                        }
                     }
                 }
+            } else {
+                quad0[0][0] = matrix[0][0];
+                quad1[0][0] = matrix[0][1];
+                quad2[0][0] = matrix[1][0];
+                quad3[0][0] = matrix[1][1];
             }
 
             return std::tuple{quad0, quad1, quad2, quad3};

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -333,16 +333,15 @@ namespace dd {
             return state;
         }
 
-        // generates decision diagram from arbitrary operators
-        mEdge makeDDFromMatrix(const CMat& matrix) {
-            /**
+        /**
             Convert a matrix to a decision diagram.
             This function converts a given matrix to a DD by iteratively breaking down the matrix
             into quarters until we have single elements that are in the correct order for a decision diagram.
             @param matrix A complex matrix to convert to a decision diagram.
             @return An mEdge that represents the decision diagram.
             @throws std::invalid_argument If the given matrix is not square or its length is not a power of two.
-            */
+        **/
+        mEdge makeDDFromMatrix(const CMat& matrix) {
 
             if (matrix.empty()) {
                 return mEdge::one;
@@ -668,13 +667,13 @@ namespace dd {
             return makeDDNode<vNode>(level, {zeroSuccessor, oneSuccessor}, true);
         }
 
-        std::tuple<CMat, CMat, CMat, CMat> quarterMatrix(const CMat& matrix) {
-            /**
+        /**
 
-            Splits a given square matrix into four smaller matrices, representing the four quadrants of the original matrix.
-            @param matrix the matrix to be split into quadrants.
-            @return a tuple of four matrices representing the four quadrants of the original matrix.
-            */
+        Splits a given square matrix into four smaller matrices, representing the four quadrants of the original matrix.
+                                                                         @param matrix the matrix to be split into quadrants.
+                                                                         @return a tuple of four matrices representing the four quadrants of the original matrix.
+                                                                         */
+        std::tuple<CMat, CMat, CMat, CMat> quarterMatrix(const CMat& matrix) {
             const auto length = matrix.size();
             const auto half   = length / 2;
 
@@ -700,17 +699,17 @@ namespace dd {
             return std::tuple{quad0, quad1, quad2, quad3};
         }
 
+        /**
+        Converts a vectorized matrix into a decision diagram starting from the top qubit level.
+                @param begin an iterator to the beginning of the range of complex numbers representing the matrix.
+                @param end an iterator to the end of the range of complex numbers representing the matrix.
+                @param level the qubit level at which to start building the DD.
+                @return a DD representing the matrix.
+        **/
         mEdge makeDDFromMatrix(const CVec::const_iterator& begin,
                                const CVec::const_iterator& end,
                                const Qubit                 level) {
-            /**
 
-            Converts a vectorized matrix into a decision diagram starting from the top qubit level.
-             @param begin an iterator to the beginning of the range of complex numbers representing the matrix.
-             @param end an iterator to the end of the range of complex numbers representing the matrix.
-             @param level the qubit level at which to start building the DD.
-             @return a DD representing the matrix.
-            */
             if (level == 0) {
                 const auto& zeroWeight  = cn.getCached(begin->real(), begin->imag());
                 auto        element     = std::next(begin);
@@ -1718,8 +1717,7 @@ namespace dd {
         }
 
     public:
-        fp expectationValue(const mEdge& x, const vEdge& y) {
-            /**
+        /**
             Calculates the expectation value of an operator x with respect to a quantum state y given their corresponding decision diagrams.
             @param x a matrix DD representing the operator
             @param y a vector DD representing the quantum state
@@ -1728,8 +1726,8 @@ namespace dd {
             @note This function calls the multiply() function to apply the operator to the quantum state, then calls innerProduct()
                   to calculate the overlap between the original state and the applied state i.e. <Psi| Psi'> = <Psi| (Op|Psi>).
                   It also calls the garbageCollect() function to free up any unused memory.
-            **/
-
+        **/
+        fp expectationValue(const mEdge& x, const vEdge& y) {
             if (x.p->v != y.p->v) {
                 throw std::invalid_argument("Observable and state must act on the same number of qubits to compute the expectation value.");
             }

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -362,10 +362,16 @@ namespace dd {
 
             const auto level = static_cast<Qubit>(std::log2(length) - 1);
 
-            // Bit weird to use begin and end here, could be better to iterate over
-            // Each row of the matrix
+            // Matrix needs to be flattened in a specific way
+            // (a00, a01, | a02, a03,
+            //  a10, a11, | a12, a13,
+            //  ---------------------
+            //  a20, a21, | a22, a23,
+            //  a30, a31, | a32, a33)
+            // -->
+            // (0 Successor, 1 Successor, 2 Successor, 3 Successor)
+            // (a00, a01, a10, a11, | a02, a03, a12, a13, | a20, a21, a30, a31, | a22, a23, a32, a33)
             CVec flattenedMatrix;
-
             if (level > 0) {
                 CVec quad0;
                 CVec quad1;

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -683,25 +683,18 @@ namespace dd {
             CMat quad2 = CMat(static_cast<size_t>(half), CVec(static_cast<size_t>(half), {0.0, 0.0}));
             CMat quad3 = CMat(static_cast<size_t>(half), CVec(static_cast<size_t>(half), {0.0, 0.0}));
 
-            if (length > 2) {
-                for (std::vector<double>::size_type i = 0; i < length; ++i) {
-                    for (std::vector<double>::size_type j = 0; j < length; ++j) {
-                        if (i < half && j < half) {
-                            quad0[i % half][j % half] = matrix[i][j];
-                        } else if (i < half && j >= half) {
-                            quad1[i % half][j % half] = matrix[i][j];
-                        } else if (i >= half && j < half) {
-                            quad2[i % half][j % half] = matrix[i][j];
-                        } else if (i >= half && j >= half) {
-                            quad3[i % half][j % half] = matrix[i][j];
-                        }
+            for (std::vector<double>::size_type i = 0; i < length; ++i) {
+                for (std::vector<double>::size_type j = 0; j < length; ++j) {
+                    if (i < half && j < half) {
+                        quad0[i % half][j % half] = matrix[i][j];
+                    } else if (i < half && j >= half) {
+                        quad1[i % half][j % half] = matrix[i][j];
+                    } else if (i >= half && j < half) {
+                        quad2[i % half][j % half] = matrix[i][j];
+                    } else if (i >= half && j >= half) {
+                        quad3[i % half][j % half] = matrix[i][j];
                     }
                 }
-            } else {
-                quad0[0][0] = matrix[0][0];
-                quad1[0][0] = matrix[0][1];
-                quad2[0][0] = matrix[1][0];
-                quad3[0][0] = matrix[1][1];
             }
 
             return std::tuple{quad0, quad1, quad2, quad3};

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -335,6 +335,15 @@ namespace dd {
 
         // generates decision diagram from arbitrary operators
         mEdge makeDDFromMatrix(const CMat& matrix) {
+            /**
+            Convert a matrix to a decision diagram.
+            This function converts a given matrix to a DD by iteratively breaking down the matrix
+            into quarters until we have single elements that are in the correct order for a decision diagram.
+            @param matrix A complex matrix to convert to a decision diagram.
+            @return An mEdge that represents the decision diagram.
+            @throws std::invalid_argument If the given matrix is not square or its length is not a power of two.
+            */
+
             if (matrix.empty()) {
                 return mEdge::one;
             }
@@ -659,7 +668,13 @@ namespace dd {
             return makeDDNode<vNode>(level, {zeroSuccessor, oneSuccessor}, true);
         }
 
-        std::tuple<CMat, CMat, CMat, CMat> quarterMatrix(const CMat& matrix, const std::vector<double>::size_type d = 2) {
+        std::tuple<CMat, CMat, CMat, CMat> quarterMatrix(const CMat& matrix) {
+            /**
+
+            Splits a given square matrix into four smaller matrices, representing the four quadrants of the original matrix.
+            @param matrix the matrix to be split into quadrants.
+            @return a tuple of four matrices representing the four quadrants of the original matrix.
+            */
             const auto length = matrix.size();
             const auto half   = length / 2;
 
@@ -668,7 +683,7 @@ namespace dd {
             CMat quad2 = CMat(static_cast<size_t>(half), CVec(static_cast<size_t>(half), {0.0, 0.0}));
             CMat quad3 = CMat(static_cast<size_t>(half), CVec(static_cast<size_t>(half), {0.0, 0.0}));
 
-            if (length > d) {
+            if (length > 2) {
                 for (std::vector<double>::size_type i = 0; i < length; ++i) {
                     for (std::vector<double>::size_type j = 0; j < length; ++j) {
                         if (i < half && j < half) {
@@ -695,6 +710,14 @@ namespace dd {
         mEdge makeDDFromMatrix(const CVec::const_iterator& begin,
                                const CVec::const_iterator& end,
                                const Qubit                 level) {
+            /**
+
+            Converts a vectorized matrix into a decision diagram starting from the top qubit level.
+             @param begin an iterator to the beginning of the range of complex numbers representing the matrix.
+             @param end an iterator to the end of the range of complex numbers representing the matrix.
+             @param level the qubit level at which to start building the DD.
+             @return a DD representing the matrix.
+            */
             if (level == 0) {
                 const auto& zeroWeight  = cn.getCached(begin->real(), begin->imag());
                 auto        element     = std::next(begin);

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -372,24 +372,26 @@ namespace dd {
                 CVec quad2;
                 CVec quad3;
 
-                for (int i = 0; i < length; ++i) {
-                    for (int j = 0; j < length; ++j) {
-                        std::cout << matrix[i][j] << "\n";
-                        if (i < length / 2 && j < length / 2) {
-                            quad0.emplace_back(matrix[i][j]);
-                        } else if (i < length / 2 && j >= length / 2) {
-                            quad1.emplace_back(matrix[i][j]);
-                        } else if (i >= length / 2 && j < length / 2) {
-                            quad2.emplace_back(matrix[i][j]);
-                        } else if (i >= length / 2 && j >= length / 2) {
-                            quad3.emplace_back(matrix[i][j]);
+                for (int requiredIterations = level; requiredIterations > 0; --requiredIterations){
+                    for (int i = 0; i < length; ++i) {
+                        for (int j = 0; j < length; ++j) {
+                            std::cout << matrix[i][j] << "\n";
+                            if (i < length / 2 && j < length / 2) {
+                                quad0.emplace_back(matrix[i][j]);
+                            } else if (i < length / 2 && j >= length / 2) {
+                                quad1.emplace_back(matrix[i][j]);
+                            } else if (i >= length / 2 && j < length / 2) {
+                                quad2.emplace_back(matrix[i][j]);
+                            } else if (i >= length / 2 && j >= length / 2) {
+                                quad3.emplace_back(matrix[i][j]);
+                            }
                         }
                     }
+                    flattenedMatrix.insert(flattenedMatrix.end(), quad0.begin(), quad0.end());
+                    flattenedMatrix.insert(flattenedMatrix.end(), quad1.begin(), quad1.end());
+                    flattenedMatrix.insert(flattenedMatrix.end(), quad2.begin(), quad2.end());
+                    flattenedMatrix.insert(flattenedMatrix.end(), quad3.begin(), quad3.end());
                 }
-                flattenedMatrix.insert(flattenedMatrix.end(), quad0.begin(), quad0.end());
-                flattenedMatrix.insert(flattenedMatrix.end(), quad1.begin(), quad1.end());
-                flattenedMatrix.insert(flattenedMatrix.end(), quad2.begin(), quad2.end());
-                flattenedMatrix.insert(flattenedMatrix.end(), quad3.begin(), quad3.end());
             } else {
                 for (int i = 0; i < length; ++i) {
                     for (int j = 0; j < length; ++j) {

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -314,7 +314,7 @@ namespace dd {
             }
 
             if (length == 1) {
-                return vEdge::terminal(cn.lookup(stateVector[0].real(), stateVector[0].imag()));
+                return vEdge::terminal(cn.lookup(stateVector[0]));
             }
 
             [[maybe_unused]] const auto before = cn.cacheCount();
@@ -358,7 +358,7 @@ namespace dd {
             }
 
             if (length == 1) {
-                return mEdge::terminal(cn.lookup(matrix[0][0].real(), matrix[0][0].imag()));
+                return mEdge::terminal(cn.lookup(matrix[0][0]));
             }
 
             [[maybe_unused]] const auto before = cn.cacheCount();

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -660,13 +660,13 @@ namespace dd {
             const auto colMid = (colStart + colEnd) / 2;
 
             const auto edge0 =
-                    makeDDFromMatrix(matrix, level-1, rowStart, rowMid, colStart, colMid);
+                    makeDDFromMatrix(matrix, level - 1, rowStart, rowMid, colStart, colMid);
             const auto edge1 =
-                    makeDDFromMatrix(matrix, level-1, rowStart, rowMid, colMid, colEnd);
+                    makeDDFromMatrix(matrix, level - 1, rowStart, rowMid, colMid, colEnd);
             const auto edge2 =
-                    makeDDFromMatrix(matrix, level-1, rowMid, rowEnd, colStart, colMid);
+                    makeDDFromMatrix(matrix, level - 1, rowMid, rowEnd, colStart, colMid);
             const auto edge3 =
-                    makeDDFromMatrix(matrix, level-1, rowMid, rowEnd, colMid, colEnd);
+                    makeDDFromMatrix(matrix, level - 1, rowMid, rowEnd, colMid, colEnd);
 
             return makeDDNode<mNode>(level, {edge0, edge1, edge2, edge3}, true);
         }

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -342,7 +342,6 @@ namespace dd {
             @throws std::invalid_argument If the given matrix is not square or its length is not a power of two.
         **/
         mEdge makeDDFromMatrix(const CMat& matrix) {
-
             if (matrix.empty()) {
                 return mEdge::one;
             }
@@ -364,35 +363,7 @@ namespace dd {
             [[maybe_unused]] const auto before = cn.cacheCount();
 
             const auto level = static_cast<Qubit>(std::log2(length) - 1);
-            /*
-            CVec flattenedMatrix;
 
-            std::tuple matrices               = quarterMatrix(matrix);
-            auto [quad0, quad1, quad2, quad3] = matrices;
-            std::vector<CMat> allMatrices;
-            allMatrices.push_back(quad0);
-            allMatrices.push_back(quad1);
-            allMatrices.push_back(quad2);
-            allMatrices.push_back(quad3);
-
-            for (Qubit requiredIterations = level; requiredIterations > 0; requiredIterations--) {
-                // Iteratively breaks down matrices into quarters until we have single elements
-                // which are in the correct order for a decision diagram
-                auto previousMatrices = allMatrices;
-                allMatrices           = {};
-                for (auto previousMatrix: previousMatrices) {
-                    std::tuple subMatrices = quarterMatrix(previousMatrix);
-                    allMatrices.push_back(std::get<0>(subMatrices));
-                    allMatrices.push_back(std::get<1>(subMatrices));
-                    allMatrices.push_back(std::get<2>(subMatrices));
-                    allMatrices.push_back(std::get<3>(subMatrices));
-                }
-            }
-
-            for (auto singleElementMatrix: allMatrices) {
-                flattenedMatrix.emplace_back(singleElementMatrix[0][0]);
-            }
-            */
             auto matrixDD = makeDDFromMatrix(matrix, level, 0, length, 0, width);
 
             if (matrixDD.w != Complex::zero) {
@@ -668,38 +639,6 @@ namespace dd {
         }
 
         /**
-
-        Splits a given square matrix into four smaller matrices, representing the four quadrants of the original matrix.
-                                                                         @param matrix the matrix to be split into quadrants.
-                                                                         @return a tuple of four matrices representing the four quadrants of the original matrix.
-                                                                         */
-        std::tuple<CMat, CMat, CMat, CMat> quarterMatrix(const CMat& matrix) {
-            const auto length = matrix.size();
-            const auto half   = length / 2;
-
-            CMat quad0 = CMat(static_cast<size_t>(half), CVec(static_cast<size_t>(half), {0.0, 0.0}));
-            CMat quad1 = CMat(static_cast<size_t>(half), CVec(static_cast<size_t>(half), {0.0, 0.0}));
-            CMat quad2 = CMat(static_cast<size_t>(half), CVec(static_cast<size_t>(half), {0.0, 0.0}));
-            CMat quad3 = CMat(static_cast<size_t>(half), CVec(static_cast<size_t>(half), {0.0, 0.0}));
-
-            for (std::vector<double>::size_type i = 0; i < length; ++i) {
-                for (std::vector<double>::size_type j = 0; j < length; ++j) {
-                    if (i < half && j < half) {
-                        quad0[i % half][j % half] = matrix[i][j];
-                    } else if (i < half && j >= half) {
-                        quad1[i % half][j % half] = matrix[i][j];
-                    } else if (i >= half && j < half) {
-                        quad2[i % half][j % half] = matrix[i][j];
-                    } else if (i >= half && j >= half) {
-                        quad3[i % half][j % half] = matrix[i][j];
-                    }
-                }
-            }
-
-            return std::tuple{quad0, quad1, quad2, quad3};
-        }
-
-        /**
         Converts a vectorized matrix into a decision diagram starting from the top qubit level.
                 @param begin an iterator to the beginning of the range of complex numbers representing the matrix.
                 @param end an iterator to the end of the range of complex numbers representing the matrix.
@@ -728,8 +667,6 @@ namespace dd {
                     makeDDFromMatrix(matrix, level-1, rowMid, rowEnd, colStart, colMid);
             const auto edge3 =
                     makeDDFromMatrix(matrix, level-1, rowMid, rowEnd, colMid, colEnd);
-
-            return makeDDNode<mNode>(level, {edge0, edge1, edge2, edge3}, true);
 
             return makeDDNode<mNode>(level, {edge0, edge1, edge2, edge3}, true);
         }

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -334,11 +334,9 @@ namespace dd {
         }
 
         /**
-            Convert a matrix to a decision diagram.
-            This function converts a given matrix to a DD by iteratively breaking down the matrix
-            into quarters until we have single elements that are in the correct order for a decision diagram.
-            @param matrix A complex matrix to convert to a decision diagram.
-            @return An mEdge that represents the decision diagram.
+            Converts a given matrix to a decision diagram
+            @param matrix A complex matrix to convert to a DD.
+            @return An mEdge that represents the DD.
             @throws std::invalid_argument If the given matrix is not square or its length is not a power of two.
         **/
         mEdge makeDDFromMatrix(const CMat& matrix) {
@@ -639,11 +637,21 @@ namespace dd {
         }
 
         /**
-        Converts a vectorized matrix into a decision diagram starting from the top qubit level.
-                @param begin an iterator to the beginning of the range of complex numbers representing the matrix.
-                @param end an iterator to the end of the range of complex numbers representing the matrix.
-                @param level the qubit level at which to start building the DD.
-                @return a DD representing the matrix.
+        Constructs a decision diagram (DD) from a complex matrix using a recursive algorithm.
+        @param matrix The complex matrix from which to create the DD.
+        @param level The current level of recursion. Starts at the highest level of the matrix (log base 2 of the matrix size - 1).
+        @param rowStart The starting row of the quadrant being processed.
+        @param rowEnd The ending row of the quadrant being processed.
+        @param colStart The starting column of the quadrant being processed.
+        @param colEnd The ending column of the quadrant being processed.
+        @return An mEdge representing the root node of the created DD.
+        @throw std::invalid_argument If level is negative.
+        @details This function recursively breaks down the matrix into quadrants until each quadrant has only one element.
+        At each level of recursion, four new edges are created, one for each quadrant of the matrix.
+        The four resulting decision diagram edges are used to create a new decision diagram node at the current level,
+        and this node is returned as the result of the current recursive call.
+        At the base case of recursion, the matrix has only one element, which is converted into a terminal node of the decision diagram.
+        @note This function assumes that the matrix size is a power of two.
         **/
         mEdge makeDDFromMatrix(const CMat& matrix, const Qubit level,
                                const std::size_t rowStart, const std::size_t rowEnd,

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -333,7 +333,7 @@ namespace dd {
             return state;
         }
 
-        // generates decision diagram from arbitrary 1- and 2-qubit operators
+        // generates decision diagram from arbitrary operators
         mEdge makeDDFromMatrix(const CMat& matrix) {
             if (matrix.empty()) {
                 return mEdge::one;
@@ -659,7 +659,7 @@ namespace dd {
             return makeDDNode<vNode>(level, {zeroSuccessor, oneSuccessor}, true);
         }
 
-        std::tuple<CMat, CMat, CMat, CMat> quarterMatrix(const CMat& matrix) {
+        std::tuple<CMat, CMat, CMat, CMat> quarterMatrix(const CMat& matrix, const std::vector<double>::size_type d = 2) {
             const auto length = matrix.size();
             const auto half   = length / 2;
 
@@ -668,7 +668,7 @@ namespace dd {
             CMat quad2 = CMat(static_cast<size_t>(half), CVec(static_cast<size_t>(half), {0.0, 0.0}));
             CMat quad3 = CMat(static_cast<size_t>(half), CVec(static_cast<size_t>(half), {0.0, 0.0}));
 
-            if (length > 1) {
+            if (length > d) {
                 for (std::vector<double>::size_type i = 0; i < length; ++i) {
                     for (std::vector<double>::size_type j = 0; j < length; ++j) {
                         if (i < half && j < half) {

--- a/test/test_package.cpp
+++ b/test/test_package.cpp
@@ -1438,101 +1438,83 @@ TEST(DDPackageTest, expectationValueExceptions) {
 }
 
 TEST(DDPackageTest, DDFromSingleQubitMatrix) {
-    auto row0        = dd::CVec{0, 1};
-    auto row1        = dd::CVec{2, 3};
-    auto inputMatrix = dd::CMat{row0, row1};
+    const auto inputMatrix = dd::CMat{{dd::SQRT2_2, dd::SQRT2_2},
+                                      {dd::SQRT2_2, -dd::SQRT2_2}};
 
     const dd::QubitCount nrQubits = 1;
-    auto                 dd       = std::make_unique<dd::Package<>>(nrQubits);
-    auto                 matDD    = dd->makeDDFromMatrix(inputMatrix);
+    const auto                 dd       = std::make_unique<dd::Package<>>(nrQubits);
+    const auto                 matDD    = dd->makeDDFromMatrix(inputMatrix);
 
-    auto outputMatrix = dd->getMatrix(matDD);
+    const auto outputMatrix = dd->getMatrix(matDD);
 
-    for (std::vector<double>::size_type i = 0; i < outputMatrix.size(); i++) {
-        for (std::vector<double>::size_type j = 0; j < outputMatrix.size(); j++) {
-            EXPECT_EQ(inputMatrix[i][j], outputMatrix[i][j]);
-        }
-    }
+    EXPECT_EQ(inputMatrix, outputMatrix);
 }
 
 TEST(DDPackageTest, DDFromTwoQubitMatrix) {
-    auto row0        = dd::CVec{0, 1, 2, 3};
-    auto row1        = dd::CVec{4, 5, 6, 7};
-    auto row2        = dd::CVec{8, 9, 10, 11};
-    auto row3        = dd::CVec{12, 13, 14, 15};
-    auto inputMatrix = dd::CMat{row0, row1, row2, row3};
+    const auto inputMatrix = dd::CMat{{1, 0, 0, 0},
+                                      {0, 1, 0, 0},
+                                      {0, 0, 0, 1},
+                                      {0, 0, 1, 0}};
 
     const dd::QubitCount nrQubits     = 2;
-    auto                 dd           = std::make_unique<dd::Package<>>(nrQubits);
-    auto                 matDD        = dd->makeDDFromMatrix(inputMatrix);
-    auto                 outputMatrix = dd->getMatrix(matDD);
+    const auto                 dd           = std::make_unique<dd::Package<>>(nrQubits);
+    const auto                 matDD        = dd->makeDDFromMatrix(inputMatrix);
+    const auto                 outputMatrix = dd->getMatrix(matDD);
 
-    for (std::vector<double>::size_type i = 0; i < outputMatrix.size(); i++) {
-        for (std::vector<double>::size_type j = 0; j < outputMatrix.size(); j++) {
-            EXPECT_EQ(inputMatrix[i][j], outputMatrix[i][j]);
-        }
-    }
+    EXPECT_EQ(inputMatrix, outputMatrix);
 }
 
 TEST(DDPackageTest, DDFromThreeQubitMatrix) {
-    auto row0        = dd::CVec{0, 1, 2, 3, 4, 5, 6, 7};
-    auto row1        = dd::CVec{8, 9, 10, 11, 12, 13, 14, 15};
-    auto row2        = dd::CVec{16, 17, 18, 19, 20, 21, 22, 23};
-    auto row3        = dd::CVec{24, 25, 26, 27, 28, 29, 30, 31};
-    auto row4        = dd::CVec{32, 33, 34, 35, 36, 37, 38, 39};
-    auto row5        = dd::CVec{40, 41, 42, 43, 44, 45, 46, 47};
-    auto row6        = dd::CVec{48, 49, 50, 51, 52, 53, 54, 55};
-    auto row7        = dd::CVec{56, 57, 58, 59, 60, 61, 62, 63};
-    auto inputMatrix = dd::CMat{row0, row1, row2, row3, row4, row5, row6, row7};
+    const auto inputMatrix = dd::CMat{{1, 0, 0, 0, 0, 0, 0, 0},
+                                      {0, 1, 0, 0, 0, 0, 0, 0},
+                                      {0, 0, 1, 0, 0, 0, 0, 0},
+                                      {0, 0, 0, 1, 0, 0, 0, 0},
+                                      {0, 0, 0, 0, 1, 0, 0, 0},
+                                      {0, 0, 0, 0, 0, 1, 0, 0},
+                                      {0, 0, 0, 0, 0, 0, 0, 1},
+                                      {0, 0, 0, 0, 0, 0, 1, 0}};
 
     const dd::QubitCount nrQubits = 3;
-    auto                 dd       = std::make_unique<dd::Package<>>(nrQubits);
-    auto                 matDD    = dd->makeDDFromMatrix(inputMatrix);
+    const auto                 dd       = std::make_unique<dd::Package<>>(nrQubits);
+    const auto                 matDD    = dd->makeDDFromMatrix(inputMatrix);
 
-    auto outputMatrix = dd->getMatrix(matDD);
+    const auto outputMatrix = dd->getMatrix(matDD);
 
-    for (std::vector<double>::size_type i = 0; i < outputMatrix.size(); i++) {
-        for (std::vector<double>::size_type j = 0; j < outputMatrix.size(); j++) {
-            EXPECT_EQ(inputMatrix[i][j], outputMatrix[i][j]);
-        }
-    }
+    EXPECT_EQ(inputMatrix, outputMatrix);
 }
 
 TEST(DDPackageTest, DDFromEmptyMatrix) {
-    auto inputMatrix = dd::CMat{};
+    const auto inputMatrix = dd::CMat{};
 
     const dd::QubitCount nrQubits = 3;
-    auto                 dd       = std::make_unique<dd::Package<>>(nrQubits);
+    const auto                 dd       = std::make_unique<dd::Package<>>(nrQubits);
     EXPECT_EQ(dd->makeDDFromMatrix(inputMatrix), dd::mEdge::one);
 }
 
 TEST(DDPackageTest, DDFromNonPowerOfTwoMatrix) {
-    auto row0        = dd::CVec{0, 1, 2};
-    auto row1        = dd::CVec{3, 4, 5};
-    auto row2        = dd::CVec{6, 7, 8};
-    auto inputMatrix = dd::CMat{row0, row1, row2};
+    auto inputMatrix = dd::CMat{{0, 1, 2},
+                                {3, 4, 5},
+                                {6, 7, 8}};
 
     const dd::QubitCount nrQubits = 3;
-    auto                 dd       = std::make_unique<dd::Package<>>(nrQubits);
-    EXPECT_ANY_THROW(dd->makeDDFromMatrix(inputMatrix));
+    const auto                 dd       = std::make_unique<dd::Package<>>(nrQubits);
+    EXPECT_THROW(dd->makeDDFromMatrix(inputMatrix), std::invalid_argument);
 }
 
 TEST(DDPackageTest, DDFromNonSquareMatrix) {
-    auto row0        = dd::CVec{0, 1, 2, 3};
-    auto row1        = dd::CVec{4, 5, 6, 7};
-    auto inputMatrix = dd::CMat{row0, row1};
+    const auto inputMatrix = dd::CMat{{0, 1, 2, 3},
+                                {4, 5, 6, 7}};
 
     const dd::QubitCount nrQubits = 3;
-    auto                 dd       = std::make_unique<dd::Package<>>(nrQubits);
-    EXPECT_ANY_THROW(dd->makeDDFromMatrix(inputMatrix));
+    const auto                 dd       = std::make_unique<dd::Package<>>(nrQubits);
+    EXPECT_THROW(dd->makeDDFromMatrix(inputMatrix), std::invalid_argument);
 }
 
 TEST(DDPackageTest, DDFromSingleELementMatrix) {
-    auto row0        = dd::CVec{1};
-    auto inputMatrix = dd::CMat{row0};
+    const auto inputMatrix = dd::CMat{{1}};
 
     const dd::QubitCount nrQubits = 1;
-    auto                 dd       = std::make_unique<dd::Package<>>(nrQubits);
+    const auto                 dd       = std::make_unique<dd::Package<>>(nrQubits);
 
-    EXPECT_EQ(dd->makeDDFromMatrix(inputMatrix), dd::mEdge::terminal(dd::Complex::one));
+    EXPECT_EQ(dd->makeDDFromMatrix(inputMatrix), dd::mEdge::one);
 }

--- a/test/test_package.cpp
+++ b/test/test_package.cpp
@@ -1436,3 +1436,28 @@ TEST(DDPackageTest, expectationValueExceptions) {
 
     EXPECT_ANY_THROW(dd->expectationValue(xGate, zeroState));
 }
+
+TEST(DDPackageTest, testArbitraryMatrixDD) {
+    const dd::QubitCount nrQubits = 1;
+    const int size = static_cast<int>(std::pow(2, nrQubits));
+
+    dd::CVec tmp;
+    for (dd::Qubit col = 0; col < static_cast<dd::Qubit>(size); ++col) {
+        tmp.emplace_back(2.);
+    }
+
+    dd::CMat arbitraryMatrix;
+    for (dd::Qubit row = 0; row < static_cast<dd::Qubit>(size); ++row) {
+        arbitraryMatrix.emplace_back(tmp);
+    }
+
+    auto       dd        = std::make_unique<dd::Package<>>(nrQubits);
+    auto matDD = dd->makeDDFromMatrix(arbitraryMatrix);
+    // auto test = dd
+    dd->printMatrix(matDD);
+    // const dd::QubitCount nrQubits = 1;
+
+    // auto       dd        = std::make_unique<dd::Package<>>(nrQubits);
+    // const auto zeroState = dd->makeZeroState(nrQubits);
+    // EXPECT_ANY_THROW(dd->expectationValue(xGate, zeroState));
+}

--- a/test/test_package.cpp
+++ b/test/test_package.cpp
@@ -1437,13 +1437,18 @@ TEST(DDPackageTest, expectationValueExceptions) {
     EXPECT_ANY_THROW(dd->expectationValue(xGate, zeroState));
 }
 
-TEST(DDPackageTest, testArbitraryMatrixDD) {
-    const dd::QubitCount nrQubits = 1;
+TEST(DDPackageTest, DDFromMatrixEmpty) {
+    const dd::QubitCount nrQubits = 2;
     const int size = static_cast<int>(std::pow(2, nrQubits));
 
     dd::CVec tmp;
     for (dd::Qubit col = 0; col < static_cast<dd::Qubit>(size); ++col) {
-        tmp.emplace_back(2.);
+        if ((col % 2) != 0) {
+            tmp.emplace_back(2.);
+        } else {
+            tmp.emplace_back(3.);
+        }
+
     }
 
     dd::CMat arbitraryMatrix;
@@ -1453,11 +1458,27 @@ TEST(DDPackageTest, testArbitraryMatrixDD) {
 
     auto       dd        = std::make_unique<dd::Package<>>(nrQubits);
     auto matDD = dd->makeDDFromMatrix(arbitraryMatrix);
-    // auto test = dd
     dd->printMatrix(matDD);
-    // const dd::QubitCount nrQubits = 1;
+}
 
-    // auto       dd        = std::make_unique<dd::Package<>>(nrQubits);
-    // const auto zeroState = dd->makeZeroState(nrQubits);
-    // EXPECT_ANY_THROW(dd->expectationValue(xGate, zeroState));
+TEST(DDPackageTest, DDFromMatrixZeros) {
+
+    auto row0 = dd::CVec{0., 0., 1., 2.};
+    auto row1 = dd::CVec{0., 0., 3., 4.};
+    auto row2 = dd::CVec{0., 0., 0., 0.};
+    auto row3 = dd::CVec{0., 0., 0., 0.};
+    auto arbitraryMatrix = dd::CMat{row0, row1, row2, row3};
+
+    /*
+    auto row0 = dd::CVec{0., 0.};
+    auto row1 = dd::CVec{0., 1.};
+    auto arbitraryMatrix = dd::CMat{row0, row1};
+    */
+
+    const dd::QubitCount nrQubits = 2;
+    auto       dd        = std::make_unique<dd::Package<>>(nrQubits);
+    auto matDD = dd->makeDDFromMatrix(arbitraryMatrix);
+    // EXPECT_EQ(dd->makeStateFromVector(v), dd::vEdge::one);
+
+    dd->printMatrix(matDD);
 }

--- a/test/test_package.cpp
+++ b/test/test_package.cpp
@@ -1462,11 +1462,10 @@ TEST(DDPackageTest, DDFromMatrixEmpty) {
 }
 
 TEST(DDPackageTest, DDFromMatrixZeros) {
-
-    auto row0 = dd::CVec{0., 0., 1., 2.};
-    auto row1 = dd::CVec{0., 0., 3., 4.};
-    auto row2 = dd::CVec{0., 0., 0., 0.};
-    auto row3 = dd::CVec{0., 0., 0., 0.};
+    auto row0 = dd::CVec{1, 2, 3, 4};
+    auto row1 = dd::CVec{5, 6, 7, 8};
+    auto row2 = dd::CVec{9, 10, 11, 12};
+    auto row3 = dd::CVec{13, 14, 15, 16};
     auto arbitraryMatrix = dd::CMat{row0, row1, row2, row3};
 
     /*

--- a/test/test_package.cpp
+++ b/test/test_package.cpp
@@ -1442,8 +1442,8 @@ TEST(DDPackageTest, DDFromSingleQubitMatrix) {
                                       {dd::SQRT2_2, -dd::SQRT2_2}};
 
     const dd::QubitCount nrQubits = 1;
-    const auto                 dd       = std::make_unique<dd::Package<>>(nrQubits);
-    const auto                 matDD    = dd->makeDDFromMatrix(inputMatrix);
+    const auto           dd       = std::make_unique<dd::Package<>>(nrQubits);
+    const auto           matDD    = dd->makeDDFromMatrix(inputMatrix);
 
     const auto outputMatrix = dd->getMatrix(matDD);
 
@@ -1457,9 +1457,9 @@ TEST(DDPackageTest, DDFromTwoQubitMatrix) {
                                       {0, 0, 1, 0}};
 
     const dd::QubitCount nrQubits     = 2;
-    const auto                 dd           = std::make_unique<dd::Package<>>(nrQubits);
-    const auto                 matDD        = dd->makeDDFromMatrix(inputMatrix);
-    const auto                 outputMatrix = dd->getMatrix(matDD);
+    const auto           dd           = std::make_unique<dd::Package<>>(nrQubits);
+    const auto           matDD        = dd->makeDDFromMatrix(inputMatrix);
+    const auto           outputMatrix = dd->getMatrix(matDD);
 
     EXPECT_EQ(inputMatrix, outputMatrix);
 }
@@ -1475,8 +1475,8 @@ TEST(DDPackageTest, DDFromThreeQubitMatrix) {
                                       {0, 0, 0, 0, 0, 0, 1, 0}};
 
     const dd::QubitCount nrQubits = 3;
-    const auto                 dd       = std::make_unique<dd::Package<>>(nrQubits);
-    const auto                 matDD    = dd->makeDDFromMatrix(inputMatrix);
+    const auto           dd       = std::make_unique<dd::Package<>>(nrQubits);
+    const auto           matDD    = dd->makeDDFromMatrix(inputMatrix);
 
     const auto outputMatrix = dd->getMatrix(matDD);
 
@@ -1487,7 +1487,7 @@ TEST(DDPackageTest, DDFromEmptyMatrix) {
     const auto inputMatrix = dd::CMat{};
 
     const dd::QubitCount nrQubits = 3;
-    const auto                 dd       = std::make_unique<dd::Package<>>(nrQubits);
+    const auto           dd       = std::make_unique<dd::Package<>>(nrQubits);
     EXPECT_EQ(dd->makeDDFromMatrix(inputMatrix), dd::mEdge::one);
 }
 
@@ -1497,16 +1497,16 @@ TEST(DDPackageTest, DDFromNonPowerOfTwoMatrix) {
                                 {6, 7, 8}};
 
     const dd::QubitCount nrQubits = 3;
-    const auto                 dd       = std::make_unique<dd::Package<>>(nrQubits);
+    const auto           dd       = std::make_unique<dd::Package<>>(nrQubits);
     EXPECT_THROW(dd->makeDDFromMatrix(inputMatrix), std::invalid_argument);
 }
 
 TEST(DDPackageTest, DDFromNonSquareMatrix) {
     const auto inputMatrix = dd::CMat{{0, 1, 2, 3},
-                                {4, 5, 6, 7}};
+                                      {4, 5, 6, 7}};
 
     const dd::QubitCount nrQubits = 3;
-    const auto                 dd       = std::make_unique<dd::Package<>>(nrQubits);
+    const auto           dd       = std::make_unique<dd::Package<>>(nrQubits);
     EXPECT_THROW(dd->makeDDFromMatrix(inputMatrix), std::invalid_argument);
 }
 
@@ -1514,7 +1514,7 @@ TEST(DDPackageTest, DDFromSingleELementMatrix) {
     const auto inputMatrix = dd::CMat{{1}};
 
     const dd::QubitCount nrQubits = 1;
-    const auto                 dd       = std::make_unique<dd::Package<>>(nrQubits);
+    const auto           dd       = std::make_unique<dd::Package<>>(nrQubits);
 
     EXPECT_EQ(dd->makeDDFromMatrix(inputMatrix), dd::mEdge::one);
 }

--- a/test/test_package.cpp
+++ b/test/test_package.cpp
@@ -1437,47 +1437,103 @@ TEST(DDPackageTest, expectationValueExceptions) {
     EXPECT_ANY_THROW(dd->expectationValue(xGate, zeroState));
 }
 
-TEST(DDPackageTest, DDFromMatrixEmpty) {
-    const dd::QubitCount nrQubits = 2;
-    const int size = static_cast<int>(std::pow(2, nrQubits));
 
-    dd::CVec tmp;
-    for (dd::Qubit col = 0; col < static_cast<dd::Qubit>(size); ++col) {
-        if ((col % 2) != 0) {
-            tmp.emplace_back(2.);
-        } else {
-            tmp.emplace_back(3.);
-        }
+TEST(DDPackageTest, DDFromSingleQubitMatrix) {
+    auto row0 = dd::CVec{0, 1};
+    auto row1 = dd::CVec{2, 3};
+    auto inputMatrix = dd::CMat{row0, row1};
 
-    }
-
-    dd::CMat arbitraryMatrix;
-    for (dd::Qubit row = 0; row < static_cast<dd::Qubit>(size); ++row) {
-        arbitraryMatrix.emplace_back(tmp);
-    }
-
+    const dd::QubitCount nrQubits = 1;
     auto       dd        = std::make_unique<dd::Package<>>(nrQubits);
-    auto matDD = dd->makeDDFromMatrix(arbitraryMatrix);
-    dd->printMatrix(matDD);
+    auto matDD = dd->makeDDFromMatrix(inputMatrix);
+
+    auto outputMatrix = dd->getMatrix(matDD);
+
+    for (std::vector<double>::size_type i = 0; i < outputMatrix.size(); i++) {
+        for (std::vector<double>::size_type j = 0; j < outputMatrix.size(); j++) {
+            EXPECT_EQ(inputMatrix[i][j], outputMatrix[i][j]);
+        }
+    }
 }
 
-TEST(DDPackageTest, DDFromMatrixZeros) {
-    auto row0 = dd::CVec{1, 2, 3, 4};
-    auto row1 = dd::CVec{5, 6, 7, 8};
-    auto row2 = dd::CVec{9, 10, 11, 12};
-    auto row3 = dd::CVec{13, 14, 15, 16};
-    auto arbitraryMatrix = dd::CMat{row0, row1, row2, row3};
-
-    /*
-    auto row0 = dd::CVec{0., 0.};
-    auto row1 = dd::CVec{0., 1.};
-    auto arbitraryMatrix = dd::CMat{row0, row1};
-    */
+TEST(DDPackageTest, DDFromTwoQubitMatrix) {
+    auto row0 = dd::CVec{0, 1, 2, 3};
+    auto row1 = dd::CVec{4, 5, 6, 7};
+    auto row2 = dd::CVec{8, 9, 10, 11};
+    auto row3 = dd::CVec{12, 13, 14, 15};
+    auto inputMatrix = dd::CMat{row0, row1, row2, row3};
 
     const dd::QubitCount nrQubits = 2;
     auto       dd        = std::make_unique<dd::Package<>>(nrQubits);
-    auto matDD = dd->makeDDFromMatrix(arbitraryMatrix);
-    // EXPECT_EQ(dd->makeStateFromVector(v), dd::vEdge::one);
+    auto matDD = dd->makeDDFromMatrix(inputMatrix);
+    auto outputMatrix = dd->getMatrix(matDD);
 
-    dd->printMatrix(matDD);
+    for (std::vector<double>::size_type i = 0; i < outputMatrix.size(); i++) {
+        for (std::vector<double>::size_type j = 0; j < outputMatrix.size(); j++) {
+            EXPECT_EQ(inputMatrix[i][j], outputMatrix[i][j]);
+        }
+    }
+}
+
+TEST(DDPackageTest, DDFromThreeQubitMatrix) {
+    auto row0 = dd::CVec{0, 1, 2, 3, 4, 5, 6, 7};
+    auto row1 = dd::CVec{8, 9, 10, 11, 12, 13, 14, 15};
+    auto row2 = dd::CVec{16, 17, 18, 19, 20, 21, 22, 23};
+    auto row3 = dd::CVec{24, 25, 26, 27, 28, 29, 30, 31};
+    auto row4 = dd::CVec{32, 33, 34, 35, 36, 37, 38, 39};
+    auto row5 = dd::CVec{40, 41, 42, 43, 44, 45, 46, 47};
+    auto row6 = dd::CVec{48, 49, 50, 51, 52, 53, 54, 55};
+    auto row7 = dd::CVec{56, 57, 58, 59, 60, 61, 62, 63};
+    auto inputMatrix = dd::CMat{row0, row1, row2, row3, row4, row5, row6, row7};
+
+    const dd::QubitCount nrQubits = 3;
+    auto       dd        = std::make_unique<dd::Package<>>(nrQubits);
+    auto matDD = dd->makeDDFromMatrix(inputMatrix);
+
+    auto outputMatrix = dd->getMatrix(matDD);
+
+    for (std::vector<double>::size_type i = 0; i < outputMatrix.size(); i++) {
+        for (std::vector<double>::size_type j = 0; j < outputMatrix.size(); j++) {
+            EXPECT_EQ(inputMatrix[i][j], outputMatrix[i][j]);
+        }
+    }
+}
+
+TEST(DDPackageTest, DDFromEmptyMatrix) {
+    auto inputMatrix = dd::CMat{};
+
+    const dd::QubitCount nrQubits = 3;
+    auto       dd        = std::make_unique<dd::Package<>>(nrQubits);
+    EXPECT_EQ(dd->makeDDFromMatrix(inputMatrix), dd::mEdge::one);
+}
+
+TEST(DDPackageTest, DDFromNonPowerOfTwoMatrix) {
+    auto row0 = dd::CVec{0, 1, 2};
+    auto row1 = dd::CVec{3, 4, 5};
+    auto row2 = dd::CVec{6, 7, 8};
+    auto inputMatrix = dd::CMat{row0, row1, row2};
+
+    const dd::QubitCount nrQubits = 3;
+    auto       dd        = std::make_unique<dd::Package<>>(nrQubits);
+    EXPECT_ANY_THROW(dd->makeDDFromMatrix(inputMatrix));
+}
+
+TEST(DDPackageTest, DDFromNonSquareMatrix) {
+    auto row0 = dd::CVec{0, 1, 2, 3};
+    auto row1 = dd::CVec{4, 5, 6, 7};
+    auto inputMatrix = dd::CMat{row0, row1};
+
+    const dd::QubitCount nrQubits = 3;
+    auto       dd        = std::make_unique<dd::Package<>>(nrQubits);
+    EXPECT_ANY_THROW(dd->makeDDFromMatrix(inputMatrix));
+}
+
+TEST(DDPackageTest, DDFromSingleELementMatrix) {
+    auto row0 = dd::CVec{1};
+    auto inputMatrix = dd::CMat{row0};
+
+    const dd::QubitCount nrQubits = 1;
+    auto       dd        = std::make_unique<dd::Package<>>(nrQubits);
+
+    EXPECT_EQ(dd->makeDDFromMatrix(inputMatrix), dd::mEdge::terminal(dd::Complex::one));
 }


### PR DESCRIPTION
This contains the implementation of the function makeDDFromMatrix() which allows an arbitrary matrix to be converted to a matrix decision diagram.

A private function makeDDFromMatrix() is usedrecursively to cut a matrix into fourths similar to makeStateFromVector().