### PR TITLE
🔧 Do not try to store benchmark results when run from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         working-directory: build
         run: ./test/DDPackage_bench --benchmark_format=json | tee benchmark_result.json
       - name: Store benchmark result # for pushes
-        if: ${{ github.actor != 'dependabot[bot]' }}
+        if: !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]'
         uses: rhysd/github-action-benchmark@v1
         #        if: github.event_name == 'push'
         with:


### PR DESCRIPTION
The benchmarks workflow would always fail when run from forks since it lacks write permissions on the main repository.
This PR adapts the workflow to only run from PRs that originate from the main repository.