### PR TITLE
🩹 Use fixed-width integer types

### DIFF
--- a/include/dd/Definitions.hpp
+++ b/include/dd/Definitions.hpp
@@ -16,8 +16,8 @@
 namespace dd {
     // integer type used for indexing qubits
     // needs to be a signed type to encode -1 as the index for the terminal
-    // std::int_fast8_t can at least address 128 qubits as [0, ..., 127]
-    using Qubit = std::int_fast8_t;
+    // std::int8_t can address up to 128 qubits as [0, ..., 127]
+    using Qubit = std::int8_t;
     static_assert(std::is_signed_v<Qubit>, "Type Qubit must be signed.");
 
     // integer type used for specifying numbers of qubits
@@ -25,7 +25,7 @@ namespace dd {
 
     // integer type used for reference counting
     // 32bit suffice for a max ref count of around 4 billion
-    using RefCount = std::uint_fast32_t;
+    using RefCount = std::uint32_t;
     static_assert(std::is_unsigned_v<RefCount>, "RefCount should be unsigned.");
 
     // floating point type to use
@@ -33,9 +33,9 @@ namespace dd {
     static_assert(std::is_floating_point_v<fp>, "fp should be a floating point type (float, *double*, long double)");
 
     // logic radix
-    static constexpr std::uint_fast8_t RADIX = 2;
+    static constexpr std::uint8_t RADIX = 2;
     // max no. of edges = RADIX^2
-    static constexpr std::uint_fast8_t NEDGE = RADIX * RADIX;
+    static constexpr std::uint8_t NEDGE = RADIX * RADIX;
 
     enum class BasisStates {
         zero,  // NOLINT(readability-identifier-naming)
@@ -57,7 +57,7 @@ namespace dd {
     // use hash maps for representing sparse vectors of probabilities
     using ProbabilityVector = std::unordered_map<std::size_t, fp>;
 
-    static constexpr std::uint_least64_t SERIALIZATION_VERSION = 1;
+    static constexpr std::uint64_t SERIALIZATION_VERSION = 1;
 
     // 64bit mixing hash (from MurmurHash3, https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp)
     constexpr std::size_t murmur64(std::size_t k) {

--- a/include/dd/Export.hpp
+++ b/include/dd/Export.hpp
@@ -363,7 +363,7 @@ namespace dd {
         return os;
     }
 
-    [[maybe_unused]] static std::ostream& bwEdge(const mEdge& from, const mEdge& to, std::uint_fast16_t idx, std::ostream& os, bool edgeLabels = false, bool classic = false, bool formatAsPolar = true) {
+    [[maybe_unused]] static std::ostream& bwEdge(const mEdge& from, const mEdge& to, std::uint16_t idx, std::ostream& os, bool edgeLabels = false, bool classic = false, bool formatAsPolar = true) {
         auto fromlabel = (reinterpret_cast<std::uintptr_t>(from.p) & 0x001fffffU) >> 1U;
         auto tolabel   = (reinterpret_cast<std::uintptr_t>(to.p) & 0x001fffffU) >> 1U;
 
@@ -404,7 +404,7 @@ namespace dd {
 
         return os;
     }
-    [[maybe_unused]] static std::ostream& bwEdge(const vEdge& from, const vEdge& to, std::uint_fast16_t idx, std::ostream& os, bool edgeLabels = false, [[maybe_unused]] bool classic = false, bool formatAsPolar = true) {
+    [[maybe_unused]] static std::ostream& bwEdge(const vEdge& from, const vEdge& to, std::uint16_t idx, std::ostream& os, bool edgeLabels = false, [[maybe_unused]] bool classic = false, bool formatAsPolar = true) {
         auto fromlabel = (reinterpret_cast<std::uintptr_t>(from.p) & 0x001fffffU) >> 1U;
         auto tolabel   = (reinterpret_cast<std::uintptr_t>(to.p) & 0x001fffffU) >> 1U;
 
@@ -428,7 +428,7 @@ namespace dd {
 
         return os;
     }
-    [[maybe_unused]] static std::ostream& coloredEdge(const mEdge& from, const mEdge& to, std::uint_fast16_t idx, std::ostream& os, bool edgeLabels = false, bool classic = false, bool formatAsPolar = true) {
+    [[maybe_unused]] static std::ostream& coloredEdge(const mEdge& from, const mEdge& to, std::uint16_t idx, std::ostream& os, bool edgeLabels = false, bool classic = false, bool formatAsPolar = true) {
         auto fromlabel = (reinterpret_cast<std::uintptr_t>(from.p) & 0x001fffffU) >> 1U;
         auto tolabel   = (reinterpret_cast<std::uintptr_t>(to.p) & 0x001fffffU) >> 1U;
 
@@ -467,7 +467,7 @@ namespace dd {
 
         return os;
     }
-    [[maybe_unused]] static std::ostream& coloredEdge(const vEdge& from, const vEdge& to, std::uint_fast16_t idx, std::ostream& os, bool edgeLabels = false, [[maybe_unused]] bool classic = false, bool formatAsPolar = true) {
+    [[maybe_unused]] static std::ostream& coloredEdge(const vEdge& from, const vEdge& to, std::uint16_t idx, std::ostream& os, bool edgeLabels = false, [[maybe_unused]] bool classic = false, bool formatAsPolar = true) {
         auto fromlabel = (reinterpret_cast<std::uintptr_t>(from.p) & 0x001fffffU) >> 1U;
         auto tolabel   = (reinterpret_cast<std::uintptr_t>(to.p) & 0x001fffffU) >> 1U;
 
@@ -490,7 +490,7 @@ namespace dd {
         return os;
     }
     template<class Edge>
-    static std::ostream& memoryEdge(const Edge& from, const Edge& to, std::uint_fast16_t idx, std::ostream& os, bool edgeLabels = false) {
+    static std::ostream& memoryEdge(const Edge& from, const Edge& to, std::uint16_t idx, std::ostream& os, bool edgeLabels = false) {
         auto fromlabel = (reinterpret_cast<std::uintptr_t>(from.p) & 0x001fffffU) >> 1U;
         auto tolabel   = (reinterpret_cast<std::uintptr_t>(to.p) & 0x001fffffU) >> 1U;
 
@@ -582,7 +582,7 @@ namespace dd {
             }
 
             // iterate over edges in reverse to guarantee correct proceossing order
-            for (auto i = static_cast<std::int_fast16_t>(node->p->e.size() - 1); i >= 0; --i) {
+            for (auto i = static_cast<std::int16_t>(node->p->e.size() - 1); i >= 0; --i) {
                 auto& edge = node->p->e[static_cast<std::size_t>(i)];
                 if ((!memory && edge.w.approximatelyZero()) || edge.w == Complex::zero) {
                     // potentially add zero stubs here
@@ -593,11 +593,11 @@ namespace dd {
                 q.push(&edge);
 
                 if (memory) {
-                    memoryEdge(*node, edge, static_cast<std::uint_fast16_t>(i), oss, edgeLabels);
+                    memoryEdge(*node, edge, static_cast<std::uint16_t>(i), oss, edgeLabels);
                 } else if (colored) {
-                    coloredEdge(*node, edge, static_cast<std::uint_fast16_t>(i), oss, edgeLabels, classic, formatAsPolar);
+                    coloredEdge(*node, edge, static_cast<std::uint16_t>(i), oss, edgeLabels, classic, formatAsPolar);
                 } else {
-                    bwEdge(*node, edge, static_cast<std::uint_fast16_t>(i), oss, edgeLabels, classic, formatAsPolar);
+                    bwEdge(*node, edge, static_cast<std::uint16_t>(i), oss, edgeLabels, classic, formatAsPolar);
                 }
             }
         }
@@ -816,7 +816,7 @@ namespace dd {
             }
 
             // iterate over edges in reverse to guarantee correct proceossing order
-            for (auto i = static_cast<std::int_fast16_t>(edgePtr->p->e.size() - 1); i >= 0; --i) {
+            for (auto i = static_cast<std::int16_t>(edgePtr->p->e.size() - 1); i >= 0; --i) {
                 auto& child = edgePtr->p->e[static_cast<std::size_t>(i)];
                 if (child.w.approximatelyZero()) {
                     // potentially add zero stubs here

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -2952,11 +2952,11 @@ namespace dd {
             auto         result = Edge::zero;
             ComplexValue rootweight{};
 
-            std::unordered_map<std::int_least64_t, Node*> nodes{};
-            std::int_least64_t                            nodeIndex{};
-            Qubit                                         v{};
-            std::array<ComplexValue, N>                   edgeWeights{};
-            std::array<std::int_least64_t, N>             edgeIndices{};
+            std::unordered_map<std::int64_t, Node*> nodes{};
+            std::int64_t                            nodeIndex{};
+            Qubit                                   v{};
+            std::array<ComplexValue, N>             edgeWeights{};
+            std::array<std::int64_t, N>             edgeIndices{};
             edgeIndices.fill(-2);
 
             if (readBinary) {
@@ -3061,7 +3061,7 @@ namespace dd {
 
     private:
         template<class Node, class Edge = Edge<Node>, std::size_t N = std::tuple_size_v<decltype(Node::e)>>
-        Edge deserializeNode(std::int_least64_t index, Qubit v, std::array<std::int_least64_t, N>& edgeIdx, std::array<ComplexValue, N>& edgeWeight, std::unordered_map<std::int_least64_t, Node*>& nodes) {
+        Edge deserializeNode(std::int64_t index, Qubit v, std::array<std::int64_t, N>& edgeIdx, std::array<ComplexValue, N>& edgeWeight, std::unordered_map<std::int64_t, Node*>& nodes) {
             if (index == -1) {
                 return Edge::zero;
             }
@@ -3116,7 +3116,7 @@ namespace dd {
             }
             std::stringstream sst;
             sst << "0x" << std::hex << reinterpret_cast<std::uintptr_t>(p) << std::dec
-                << "[v=" << static_cast<std::int_fast64_t>(p->v)
+                << "[v=" << static_cast<std::int64_t>(p->v)
                 << " ref=" << p->ref
                 << " hash=" << UniqueTable<Node>::hash(p)
                 << "]";

--- a/include/dd/StochasticNoiseOperationTable.hpp
+++ b/include/dd/StochasticNoiseOperationTable.hpp
@@ -30,13 +30,13 @@ namespace dd {
             table.resize(nvars);
         }
 
-        void insert(std::uint_fast8_t kind, Qubit target, const Edge& r) {
+        void insert(std::uint8_t kind, Qubit target, const Edge& r) {
             assert(kind < numberOfStochasticOperations); // There are new operations in OpType. Increase the value of numberOfOperations accordingly
             table.at(static_cast<std::size_t>(target)).at(kind) = r;
             ++count;
         }
 
-        Edge lookup(std::uint_fast8_t kind, Qubit target) {
+        Edge lookup(std::uint8_t kind, Qubit target) {
             assert(kind < numberOfStochasticOperations); // There are new operations in OpType. Increase the value of numberOfOperations accordingly
             lookups++;
             Edge r{};

--- a/test/test_package.cpp
+++ b/test/test_package.cpp
@@ -1292,7 +1292,7 @@ TEST(DDPackageTest, dStochCache) {
     dd->stochasticNoiseOperationCache.insert(2, 2, operations[2]); //insert Y operations with target 2
     dd->stochasticNoiseOperationCache.insert(3, 3, operations[3]); //insert H operations with target 3
 
-    for (std::uint_fast8_t i = 0; i < 4; i++) {
+    for (std::uint8_t i = 0; i < 4; i++) {
         for (dd::Qubit j = 0; j < 4; j++) {
             if (static_cast<dd::Qubit>(i) == j) {
                 auto op = dd->stochasticNoiseOperationCache.lookup(i, j);
@@ -1305,7 +1305,7 @@ TEST(DDPackageTest, dStochCache) {
     }
 
     dd->stochasticNoiseOperationCache.clear();
-    for (std::uint_fast8_t i = 0; i < 4; i++) {
+    for (std::uint8_t i = 0; i < 4; i++) {
         for (dd::Qubit j = 0; j < 4; j++) {
             auto op = dd->stochasticNoiseOperationCache.lookup(i, j);
             EXPECT_EQ(op.p, nullptr);


### PR DESCRIPTION
Fixes #117.

The error there is the use of `std::int_fast8_t` for `dd::Qubit`. On most systems, this actually results in an `8`bit integer type, but the standard only guarantees that this is the fastest type for handling 8bit integers on the machine, i.e., it might be wider. When it's 32bits, `MAX_POSSIBLE_QUBITS=2147483648`. Allocating a package of that size will fail on almost all systems imaginable.
This PR fixes the underlying issue by relying on fixed-width integer types. Although these are not mandated by the standard, every major platform we aim to support, provides these types. And it at least allows the program to fail at compile time on exotic systems instead of leading to a cryptic runtime error as in #117. 
We can always adapt once an exotic system pops up that we still might want to support.