### PR TITLE
fixed inner product not conjugating top edge weight

### DIFF
--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -1764,6 +1764,12 @@ namespace dd {
     public:
         ComputeTable<vEdge, vEdge, vCachedEdge, Config::CT_VEC_INNER_PROD_NBUCKET> vectorInnerProduct{};
 
+        /**
+            Calculates the inner product of two vector decision diagrams x and y.
+            @param x a vector DD representing a quantum state
+            @param y a vector DD representing a quantum state
+            @return a complex number representing the scalar product of the DDs
+        **/
         ComplexValue innerProduct(const vEdge& x, const vEdge& y) {
             if (x.p == nullptr || y.p == nullptr || x.w.approximatelyZero() || y.w.approximatelyZero()) { // the 0 case
                 return {0, 0};
@@ -1775,6 +1781,9 @@ namespace dd {
             if (y.p->v > w) {
                 w = y.p->v;
             }
+            auto xCopy = x;
+            xCopy.w = ComplexNumbers::conj(x.w); // Overall normalization factor needs to be conjugated
+                                                 // before input into recursive private function
             const ComplexValue ip = innerProduct(x, y, static_cast<Qubit>(w + 1));
 
             [[maybe_unused]] const auto after = cn.cacheCount();
@@ -1821,21 +1830,29 @@ namespace dd {
         }
 
     private:
+        /**
+            Private function to recursively calculate the inner product of two vector decision diagrams x and y with var levels.
+            @param x a vector DD representing a quantum state
+            @param y a vector DD representing a quantum state
+            @param var the number of levels contained in each vector DD
+            @return a complex number  representing the scalar product of the DDs
+            @note This function is called recursively such that the number of levels decreases each time to traverse the DDs.
+        **/
         ComplexValue innerProduct(const vEdge& x, const vEdge& y, Qubit var) {
             if (x.p == nullptr || y.p == nullptr || x.w.approximatelyZero() || y.w.approximatelyZero()) { // the 0 case
                 return {0.0, 0.0};
             }
 
-            if (var == 0) {
+            if (var == 0) { // Multiplies terminal weights
                 auto c = cn.getTemporary();
                 ComplexNumbers::mul(c, x.w, y.w);
                 return {c.r->value, c.i->value};
             }
 
             auto xCopy = x;
-            xCopy.w    = Complex::one;
+            xCopy.w    = Complex::zero; // Set to zero to generate more lookup hits
             auto yCopy = y;
-            yCopy.w    = Complex::one;
+            yCopy.w    = Complex::zero;
 
             auto r = vectorInnerProduct.lookup(xCopy, yCopy);
             if (r.p != nullptr) {
@@ -1848,17 +1865,18 @@ namespace dd {
             auto w = static_cast<Qubit>(var - 1);
 
             ComplexValue sum{0.0, 0.0};
+            // Iterates through edge weights recursively until terminal
             for (auto i = 0U; i < RADIX; i++) {
                 vEdge e1{};
                 if (!x.isTerminal() && x.p->v == w) {
                     e1 = x.p->e[i];
+                    e1.w = ComplexNumbers::conj(e1.w);
                 } else {
                     e1 = xCopy;
                 }
                 vEdge e2{};
                 if (!y.isTerminal() && y.p->v == w) {
                     e2   = y.p->e[i];
-                    e2.w = ComplexNumbers::conj(e2.w);
                 } else {
                     e2 = yCopy;
                 }

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -1782,8 +1782,8 @@ namespace dd {
                 w = y.p->v;
             }
             auto xCopy = x;
-            xCopy.w = ComplexNumbers::conj(x.w); // Overall normalization factor needs to be conjugated
-                                                 // before input into recursive private function
+            xCopy.w    = ComplexNumbers::conj(x.w); // Overall normalization factor needs to be conjugated
+                                                    // before input into recursive private function
             const ComplexValue ip = innerProduct(x, y, static_cast<Qubit>(w + 1));
 
             [[maybe_unused]] const auto after = cn.cacheCount();
@@ -1869,14 +1869,14 @@ namespace dd {
             for (auto i = 0U; i < RADIX; i++) {
                 vEdge e1{};
                 if (!x.isTerminal() && x.p->v == w) {
-                    e1 = x.p->e[i];
+                    e1   = x.p->e[i];
                     e1.w = ComplexNumbers::conj(e1.w);
                 } else {
                     e1 = xCopy;
                 }
                 vEdge e2{};
                 if (!y.isTerminal() && y.p->v == w) {
-                    e2   = y.p->e[i];
+                    e2 = y.p->e[i];
                 } else {
                     e2 = yCopy;
                 }
@@ -1910,8 +1910,8 @@ namespace dd {
                 throw std::invalid_argument("Observable and state must act on the same number of qubits to compute the expectation value.");
             }
 
-            auto               yPrime = multiply(x, y);
-            const ComplexValue expValue     = innerProduct(y, yPrime);
+            auto               yPrime   = multiply(x, y);
+            const ComplexValue expValue = innerProduct(y, yPrime);
 
             assert(CTEntry::approximatelyZero(expValue.i));
 

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -1911,13 +1911,13 @@ namespace dd {
             }
 
             auto               yPrime = multiply(x, y);
-            const ComplexValue ip     = innerProduct(y, yPrime);
+            const ComplexValue expValue     = innerProduct(y, yPrime);
 
-            assert(CTEntry::approximatelyZero(ip.i));
+            assert(CTEntry::approximatelyZero(expValue.i));
 
             garbageCollect();
 
-            return ip.r;
+            return expValue.r;
         }
 
         ///

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -1850,9 +1850,9 @@ namespace dd {
             }
 
             auto xCopy = x;
-            xCopy.w    = Complex::zero; // Set to zero to generate more lookup hits
+            xCopy.w    = Complex::one; // Set to one to generate more lookup hits
             auto yCopy = y;
-            yCopy.w    = Complex::zero;
+            yCopy.w    = Complex::one;
 
             auto r = vectorInnerProduct.lookup(xCopy, yCopy);
             if (r.p != nullptr) {


### PR DESCRIPTION
This pull request fixes the inner product not considering the top edge weight properly. This was not noticed until now since the inner product has been used with the fidelity which squares the result, however this change was necessary for the expectation value to work.

Included are also:
1. Renaming of variable ip to expValue in the expectationValue function
2. Swap conjugation from second input of innerProduct to first input to be more mathematically consistent (i.e. innerProduct(x, y) = <x|y>
3. Some small comments as well as docstrings for the public and private innerProduct functions.