### PR TITLE
fixed inner product bug and created test case

### DIFF
--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -1784,7 +1784,7 @@ namespace dd {
             auto xCopy = x;
             xCopy.w    = ComplexNumbers::conj(x.w); // Overall normalization factor needs to be conjugated
                                                     // before input into recursive private function
-            const ComplexValue ip = innerProduct(x, y, static_cast<Qubit>(w + 1));
+            const ComplexValue ip = innerProduct(xCopy, y, static_cast<Qubit>(w + 1));
 
             [[maybe_unused]] const auto after = cn.cacheCount();
             assert(after == before);

--- a/test/test_package.cpp
+++ b/test/test_package.cpp
@@ -1799,8 +1799,8 @@ TEST(DDPackageTest, InnerProductTopNodeConjugation) {
 
     const auto evolvedState         = dd->multiply(rxx, zeroState);
 
-    // Actual evolution results in approximately -0.4161468365471423
+    // Actual evolution results in approximately -0.416
     // If the top node in the inner product is not conjugated properly,
-    // it will result in +0.4161468365471423.
-    EXPECT_NEAR(dd->expectationValue(op, evolvedState), -0.4161468365471423, 0.001);
+    // it will result in +0.416.
+    EXPECT_NEAR(dd->expectationValue(op, evolvedState), -0.416, 0.001);
 }

--- a/test/test_package.cpp
+++ b/test/test_package.cpp
@@ -1786,3 +1786,21 @@ TEST(DDPackageTest, TwoQubitGateCreationFailure) {
 
     EXPECT_THROW(dd->makeTwoQubitGateDD(dd::CXmat, 2, 0, 1), std::runtime_error);
 }
+
+TEST(DDPackageTest, InnerProductTopNodeConjugation) {
+    // Test comes from experimental results
+    // 2 qubit state is rotated Rxx(-2) equivalent to
+    // Ising model evolution up to a time T=1
+    const dd::QubitCount nrQubits = 2;
+    const auto       dd        = std::make_unique<dd::Package<>>(nrQubits);
+    const auto zeroState = dd->makeZeroState(nrQubits);
+    const auto rxx = dd->makeRXXDD(nrQubits, 0, 1, -2);
+    const auto op     = dd->makeGateDD(dd::Zmat, nrQubits, 0);
+
+    const auto evolvedState         = dd->multiply(rxx, zeroState);
+
+    // Actual evolution results in approximately -0.4161468365471423
+    // If the top node in the inner product is not conjugated properly,
+    // it will result in +0.4161468365471423.
+    EXPECT_NEAR(dd->expectationValue(op, evolvedState), -0.4161468365471423, 0.001);
+}


### PR DESCRIPTION
This pull request fixes the conjugated variable xCopy not being input into the publc inner product function. The inner product was modified in a previous commit to consider the top level node and somehow this detail was missed in the final pull request.

A test case was also created to check that the expectation value (and therefore the inner product) works properly. This test case was based on experimental results of the Ising model evolving a state up to T=1 (i.e. a 2-qubit circuit with an Rxx(-2) rotation).