### PR TITLE
🚸 only add CMake targets if they do not exist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,55 +17,61 @@ include(cmake/PreventInSourceBuilds.cmake)
 include(cmake/CheckSubmodule.cmake)
 include(cmake/PackageAddTest.cmake)
 
-# Use the warnings specified in CompilerWarnings.cmake
-add_library(project_warnings INTERFACE)
+if(NOT TARGET project_warnings)
+  # Use the warnings specified in CompilerWarnings.cmake
+  add_library(project_warnings INTERFACE)
 
-# Standard compiler warnings
-include(cmake/CompilerWarnings.cmake)
-set_project_warnings(project_warnings)
+  # Standard compiler warnings
+  include(cmake/CompilerWarnings.cmake)
+  set_project_warnings(project_warnings)
+endif()
 
-# Interface library to set project options
-add_library(project_options INTERFACE)
+if(NOT TARGET project_options)
+  # Use the options specified in CompilerOptions.cmake
+  add_library(project_options INTERFACE)
 
-# Compiler options
-include(cmake/CompilerOptions.cmake)
-enable_project_options(project_options)
+  # Standard compiler options
+  include(cmake/CompilerOptions.cmake)
+  enable_project_options(project_options)
 
-# Sanitizer options if supported by compiler
-include(cmake/Sanitizers.cmake)
-enable_sanitizers(project_options)
+  # Sanitizer options if supported by compiler
+  include(cmake/Sanitizers.cmake)
+  enable_sanitizers(project_options)
+endif()
 
 # add main library code
-add_library(
-  ${PROJECT_NAME}
-  INTERFACE
-  include/dd/Complex.hpp
-  include/dd/ComplexCache.hpp
-  include/dd/ComplexNumbers.hpp
-  include/dd/ComplexTable.hpp
-  include/dd/ComplexValue.hpp
-  include/dd/ComputeTable.hpp
-  include/dd/Control.hpp
-  include/dd/Definitions.hpp
-  include/dd/Edge.hpp
-  include/dd/Export.hpp
-  include/dd/GateMatrixDefinitions.hpp
-  include/dd/Node.hpp
-  include/dd/Package.hpp
-  include/dd/ToffoliTable.hpp
-  include/dd/UnaryComputeTable.hpp
-  include/dd/DensityNoiseTable.hpp
-  include/dd/StochasticNoiseOperationTable.hpp
-  include/dd/UniqueTable.hpp)
+if(NOT TARGET ${PROJECT_NAME})
+  add_library(
+    ${PROJECT_NAME}
+    INTERFACE
+    include/dd/Complex.hpp
+    include/dd/ComplexCache.hpp
+    include/dd/ComplexNumbers.hpp
+    include/dd/ComplexTable.hpp
+    include/dd/ComplexValue.hpp
+    include/dd/ComputeTable.hpp
+    include/dd/Control.hpp
+    include/dd/Definitions.hpp
+    include/dd/Edge.hpp
+    include/dd/Export.hpp
+    include/dd/GateMatrixDefinitions.hpp
+    include/dd/Node.hpp
+    include/dd/Package.hpp
+    include/dd/ToffoliTable.hpp
+    include/dd/UnaryComputeTable.hpp
+    include/dd/DensityNoiseTable.hpp
+    include/dd/StochasticNoiseOperationTable.hpp
+    include/dd/UniqueTable.hpp)
 
-# add options and warnings to library
-target_link_libraries(${PROJECT_NAME} INTERFACE project_options project_warnings)
+  # add options and warnings to library
+  target_link_libraries(${PROJECT_NAME} INTERFACE project_options project_warnings)
 
-# set include directories
-target_include_directories(${PROJECT_NAME} INTERFACE include ${PROJECT_BINARY_DIR}/include)
+  # set include directories
+  target_include_directories(${PROJECT_NAME} INTERFACE include ${PROJECT_BINARY_DIR}/include)
 
-# add MQT alias
-add_library(MQT::DDPackage ALIAS ${PROJECT_NAME})
+  # add MQT alias
+  add_library(MQT::DDPackage ALIAS ${PROJECT_NAME})
+endif()
 
 # add test code
 option(BUILD_DD_PACKAGE_TESTS "Also build tests for DD package")

--- a/cmake/PackageAddTest.cmake
+++ b/cmake/PackageAddTest.cmake
@@ -1,13 +1,15 @@
 # macro to add a test executable for one of the project libraries
 macro(PACKAGE_ADD_TEST testname linklibs)
-  # create an executable in which the tests will be stored
-  add_executable(${testname} ${ARGN})
-  # link the Google test infrastructure and a default main function to the test executable.
-  target_link_libraries(${testname} PRIVATE ${linklibs} gmock gtest_main)
-  # discover tests
-  gtest_discover_tests(
-    ${testname}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" DISCOVERY_TIMEOUT 60)
-  set_target_properties(${testname} PROPERTIES FOLDER tests)
+  if(NOT TARGET ${testname})
+    # create an executable in which the tests will be stored
+    add_executable(${testname} ${ARGN})
+    # link the Google test infrastructure and a default main function to the test executable.
+    target_link_libraries(${testname} PRIVATE ${linklibs} gmock gtest_main)
+    # discover tests
+    gtest_discover_tests(
+      ${testname}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" DISCOVERY_TIMEOUT 60)
+    set_target_properties(${testname} PROPERTIES FOLDER tests)
+  endif()
 endmacro()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,19 +17,23 @@ if(NOT TARGET benchmark::benchmark)
   set_target_properties(benchmark benchmark_main PROPERTIES FOLDER extern)
 endif()
 
-add_executable(${PROJECT_NAME}_example main.cpp)
-target_link_libraries(${PROJECT_NAME}_example PRIVATE ${PROJECT_NAME})
-set_target_properties(${PROJECT_NAME}_example PROPERTIES FOLDER tests)
+if(NOT TARGET ${PROJECT_NAME}_example)
+  add_executable(${PROJECT_NAME}_example main.cpp)
+  target_link_libraries(${PROJECT_NAME}_example PRIVATE ${PROJECT_NAME})
+  set_target_properties(${PROJECT_NAME}_example PROPERTIES FOLDER tests)
+
+  # include dd_example in test suite
+  add_test(NAME ${PROJECT_NAME}_example COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_example)
+endif()
 
 # add unit tests
 package_add_test(${PROJECT_NAME}_test ${PROJECT_NAME} test_complex.cpp test_package.cpp)
 
-# include dd_example in test suite
-add_test(NAME ${PROJECT_NAME}_example COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_example)
-
-# add benchmark executable
-add_executable(${PROJECT_NAME}_bench EXCLUDE_FROM_ALL bench_package.cpp)
-# link the Google benchmark infrastructure and a default main function to the benchmark executable.
-target_link_libraries(${PROJECT_NAME}_bench PRIVATE ${PROJECT_NAME} benchmark::benchmark_main
-                                                    Threads::Threads)
-set_target_properties(${PROJECT_NAME}_bench PROPERTIES FOLDER tests)
+if(NOT TARGET ${PROJECT_NAME}_bench)
+  # add benchmark executable
+  add_executable(${PROJECT_NAME}_bench EXCLUDE_FROM_ALL bench_package.cpp)
+  # link the Google benchmark infrastructure and a default main function
+  target_link_libraries(${PROJECT_NAME}_bench PRIVATE ${PROJECT_NAME} benchmark::benchmark_main
+                                                      Threads::Threads)
+  set_target_properties(${PROJECT_NAME}_bench PROPERTIES FOLDER tests)
+endif()


### PR DESCRIPTION
This small PR makes sure that CMake are only added if they do not exist already. This avoids problems when multiple versions of the DDPackage are part of the same repository